### PR TITLE
[Fix]: Fix memory leaks when model loading

### DIFF
--- a/AL/include/Renderer/Renderer.h
+++ b/AL/include/Renderer/Renderer.h
@@ -52,6 +52,10 @@ class Renderer
 	{
 		return viewPortDescriptorSets[0];
 	}
+	std::unordered_map<std::string, std::shared_ptr<Model>> &getModelsMap()
+	{
+		return m_modelsMap;
+	}
 
   private:
 	Renderer() = default;
@@ -173,6 +177,8 @@ class Renderer
 
 	glm::mat4 projMatrix;
 	glm::mat4 viewMatirx;
+
+	std::unordered_map<std::string, std::shared_ptr<Model>> m_modelsMap;
 
 	bool firstFrame = true;
 

--- a/AL/src/Renderer/Model.cpp
+++ b/AL/src/Renderer/Model.cpp
@@ -1,33 +1,62 @@
 #include "Renderer/Model.h"
+#include "Core/App.h"
 #include "Renderer/ShaderResourceManager.h"
 
 namespace ale
 {
 std::shared_ptr<Model> Model::createModel(std::string path, std::shared_ptr<Material> &defaultMaterial)
 {
+	auto &renderer = App::get().getRenderer();
+	auto &modelsMap = renderer.getModelsMap();
+	if (modelsMap.find(path) != modelsMap.end())
+	{
+		return modelsMap[path];
+	}
 	std::shared_ptr<Model> model = std::shared_ptr<Model>(new Model());
 	model->initModel(path, defaultMaterial);
+	modelsMap[path] = model;
 	return model;
 }
 
 std::shared_ptr<Model> Model::createBoxModel(std::shared_ptr<Material> &defaultMaterial)
 {
+	auto &renderer = App::get().getRenderer();
+	auto &modelsMap = renderer.getModelsMap();
+	if (modelsMap.find("box") != modelsMap.end())
+	{
+		return modelsMap["box"];
+	}
 	std::shared_ptr<Model> model = std::shared_ptr<Model>(new Model());
 	model->initBoxModel(defaultMaterial);
+	modelsMap["box"] = model;
 	return model;
 }
 
 std::shared_ptr<Model> Model::createSphereModel(std::shared_ptr<Material> &defaultMaterial)
 {
+	auto &renderer = App::get().getRenderer();
+	auto &modelsMap = renderer.getModelsMap();
+	if (modelsMap.find("sphere") != modelsMap.end())
+	{
+		return modelsMap["sphere"];
+	}
 	std::shared_ptr<Model> model = std::shared_ptr<Model>(new Model());
 	model->initSphereModel(defaultMaterial);
+	modelsMap["sphere"] = model;
 	return model;
 }
 
 std::shared_ptr<Model> Model::createPlaneModel(std::shared_ptr<Material> &defaultMaterial)
 {
+	auto &renderer = App::get().getRenderer();
+	auto &modelsMap = renderer.getModelsMap();
+	if (modelsMap.find("plane") != modelsMap.end())
+	{
+		return modelsMap["plane"];
+	}
 	std::shared_ptr<Model> model = std::shared_ptr<Model>(new Model());
 	model->initPlaneModel(defaultMaterial);
+	modelsMap["plane"] = model;
 	return model;
 }
 


### PR DESCRIPTION
model 로드 시 메모리 누수 수정

renderer에 model의 mesh정보를 가지고 있는 unordered_map 추가
model이 추가될 때마다 이 정보를 path로 저장
새로 model을 만들기 전 이 map을 확인하여 이미 있으면 그 모델을 반환