### PR TITLE
51 feat game code 추가

### DIFF
--- a/AL-ScriptCore/src/InternalCalls.cs
+++ b/AL-ScriptCore/src/InternalCalls.cs
@@ -30,7 +30,7 @@ namespace ALEngine
 		internal extern static void TransformComponent_setPosition(ulong entityID, ref Vector3 translation);
 		#endregion
 
-		#region Input
+		#region RigidbodyComponent
 		[MethodImplAttribute(MethodImplOptions.InternalCall)]
 		internal extern static void RigidbodyComponent_addForce(ulong entityID, ref Vector3 force);
 		#endregion

--- a/AL-ScriptCore/src/Vector3.cs
+++ b/AL-ScriptCore/src/Vector3.cs
@@ -27,13 +27,24 @@ namespace ALEngine
 			Z = z;
 		}
 
-		public Vector2 XY
+		public Vector3 XY
 		{
-			get => new Vector2(X, Y);
+			get => new Vector3(X, Y, 0);
 			set
 			{
 				X = value.X;
 				Y = value.Y;
+			}
+		}
+
+		public Vector3 XYZ
+		{
+			get => new Vector3(X, Y, Z);
+			set
+			{
+				X = value.X;
+				Y = value.Y;
+				Z = value.Z;
 			}
 		}
 

--- a/AL-ScriptCore/src/Vector4.cs
+++ b/AL-ScriptCore/src/Vector4.cs
@@ -30,19 +30,21 @@ namespace ALEngine
 			W = w;
 		}
 
-		public Vector2 XY
+		public Vector4 XYZW
 		{
-			get => new Vector2(X, Y);
+			get => new Vector4(X, Y, Z, W);
 			set
 			{
 				X = value.X;
 				Y = value.Y;
+				Z = value.Z;
+				W = value.W;
 			}
 		}
 
-		public Vector3 XYZ
+		public Vector4 XYZ
 		{
-			get => new Vector3(X, Y, Z);
+			get => new Vector4(X, Y, Z, 0);
 			set
 			{
 				X = value.X;

--- a/AL/src/Physics/Rigidbody.cpp
+++ b/AL/src/Physics/Rigidbody.cpp
@@ -41,6 +41,7 @@ Rigidbody::Rigidbody(const BodyDef *bd, World *world)
 	m_angularDamping = bd->m_angularDamping;
 	m_gravityScale = bd->m_gravityScale;
 
+	m_useGravity = bd->m_useGravity;
 	m_canSleep = bd->m_canSleep;
 	m_isAwake = bd->m_isAwake;
 	m_sleepTime = 0.0f;

--- a/AL/src/Scene/Scene.cpp
+++ b/AL/src/Scene/Scene.cpp
@@ -496,8 +496,6 @@ template <> void Scene::onComponentAdded<MeshRendererComponent>(Entity entity, M
 	component.type = 0;
 	component.m_RenderingComponent =
 		RenderingComponent::createRenderingComponent(Model::createBoxModel(this->getDefaultMaterial()));
-
-	auto &bc = entity.addComponent<BoxColliderComponent>();
 }
 
 template <> void Scene::onComponentAdded<ModelComponent>(Entity entity, ModelComponent &component)

--- a/AL/src/Scripting/ScriptGlue.cpp
+++ b/AL/src/Scripting/ScriptGlue.cpp
@@ -55,7 +55,7 @@ static bool Entity_hasComponent(UUID entityID, MonoReflectionType *componentType
 {
 	// ASSERT
 	Scene *scene = ScriptingEngine::getSceneContext();
-	Entity entity = scene->createEntityWithUUID(entityID);
+	Entity entity = scene->getEntityByUUID(entityID);
 
 	MonoType *managedType = mono_reflection_type_get_type(componentType);
 	return s_EntityHasComponentFuncs.at(managedType)(entity);
@@ -116,7 +116,6 @@ static MonoObject *getScriptInstance(UUID entityID)
 // Transform
 static void TransformComponent_getPosition(UUID entityID, glm::vec3 *outPosition)
 {
-	AL_CORE_TRACE("TransformComponent_getPosition");
 	Scene *scene = ScriptingEngine::getSceneContext();
 	Entity entity = scene->getEntityByUUID(entityID);
 
@@ -128,7 +127,9 @@ static void TransformComponent_setPosition(UUID entityID, glm::vec3 *position)
 	Scene *scene = ScriptingEngine::getSceneContext();
 	Entity entity = scene->getEntityByUUID(entityID);
 
-	entity.getComponent<TransformComponent>().m_Position = *position;
+	auto &tc = entity.getComponent<TransformComponent>();
+	tc.m_Position = *position;
+	tc.m_WorldTransform = tc.getTransform();
 }
 
 // Input

--- a/Sandbox/Project/Assets/Scenes/3DExample.ale
+++ b/Sandbox/Project/Assets/Scenes/3DExample.ale
@@ -1,5 +1,29 @@
 Scene: Untitled
 Entities:
+  - Entity: 3619305722777497448
+    TagComponent:
+      Tag: Player
+    TransformComponent:
+      Position: [9.89999962, 0.899999976, 10]
+      Rotation: [0, 0, 0]
+      Scale: [1, 1, 1]
+    MeshRendererComponent:
+      MeshType: 1
+    ScriptComponent:
+      ClassName: Sandbox.Player
+      ScriptFields:
+        - Name: Speed
+          Type: Float
+          Data: 100000
+    RigidbodyComponent:
+      Mass: 1
+      Drag: 0.00100000005
+      AngularDrag: 0.00100000005
+      UseGravity: false
+    SphereColliderComponent:
+      Center: [0, 0, 0]
+      Radius: 1
+      IsTrigger: false
   - Entity: 11822122333692858422
     TagComponent:
       Tag: Camera
@@ -39,12 +63,6 @@ Entities:
       Scale: [50, 50, 1]
     MeshRendererComponent:
       MeshType: 2
-    ScriptComponent:
-      ClassName: Sandbox.Player
-      ScriptFields:
-        - Name: Speed
-          Type: Float
-          Data: 43
     BoxColliderComponent:
       Center: [0, 0, 0]
       Size: [1, 1, 1]
@@ -62,3 +80,19 @@ Entities:
       Center: [0, 1, 0]
       Size: [3, 3, 3]
       IsTrigger: false
+  - Entity: 606118099047227836
+    TagComponent:
+      Tag: Light
+    TransformComponent:
+      Position: [13.8000002, 0.5, 15.1000004]
+      Rotation: [0, 0, 0]
+      Scale: [1, 1, 1]
+    LightComponent:
+      Type: 0
+      ShadowMap: 1
+      Position: [13.8000002, 0.5, 15.1000004]
+      Direction: [0, -1, 0]
+      Color: [1, 1, 1]
+      Intensity: 1
+      InnerCutoff: 0.976296008
+      OuterCutoff: 0.953716934

--- a/Sandbox/Project/Assets/Scripts/src/Player.cs
+++ b/Sandbox/Project/Assets/Scripts/src/Player.cs
@@ -11,6 +11,7 @@ namespace Sandbox
     public class Player : Entity
     {
         private TransformComponent m_Transform;
+        private RigidbodyComponent m_Rigidbody;
 
         public float Speed;
         public float Time = 0.0f;
@@ -20,12 +21,33 @@ namespace Sandbox
             Console.WriteLine($"Player.OnCreate - {ID}");
 
             m_Transform = getComponent<TransformComponent>();
+            m_Rigidbody = getComponent<RigidbodyComponent>();
         }
 
         void onUpdate(float ts)
         {
-            // Time += ts;
-            // Console.WriteLine($"Player.OnUpdate: {ts}");
+            Vector3 velocity = Vector3.Zero;
+
+            if (Input.isKeyDown(KeyCode.W))
+            {
+                velocity.Z = -1.0f;
+            }
+            else if (Input.isKeyDown(KeyCode.S))
+            {
+                velocity.Z = 1.0f;
+            }
+
+            if (Input.isKeyDown(KeyCode.A))
+            {
+                velocity.X = -1.0f;
+            }
+            else if (Input.isKeyDown(KeyCode.D))
+            {
+                velocity.X = 1.0f;
+            }
+
+            velocity *= Speed * ts;
+            m_Rigidbody.addForce(velocity.XYZ);
         }
 
     }

--- a/Sandbox/src/EditorLayer.cpp
+++ b/Sandbox/src/EditorLayer.cpp
@@ -81,7 +81,7 @@ void EditorLayer::onUpdate(Timestep ts)
 void EditorLayer::onImGuiRender()
 {
 	// Docking space
-	// setDockingSpace();
+	setDockingSpace();
 
 	// Menu
 	setMenuBar();
@@ -100,7 +100,7 @@ void EditorLayer::onImGuiRender()
 	// UI Toolbar
 	uiToolBar();
 
-	// ImGui::End(); // DockSpace -> ImGui::Begin, End 쌍 맞추기
+	ImGui::End(); // DockSpace -> ImGui::Begin, End 쌍 맞추기
 }
 
 void EditorLayer::onEvent(Event &e)


### PR DESCRIPTION
---

#### **1. Transform 및 Rigidbody 관련 함수 추가**
- `TransformComponent_setPosition` 함수 수정
  - 기존: `entity.getComponent<TransformComponent>().m_Position = *position;`
  - 변경:  
    ```cpp
    auto &tc = entity.getComponent<TransformComponent>();
    tc.m_Position = *position;
    tc.m_WorldTransform = tc.getTransform();
    ```
  - **변경 이유**: `m_WorldTransform`을 갱신하도록 수정하여 변환 정보가 제대로 반영되도록 개선함.

- `RigidbodyComponent_addForce` 함수 추가
  - 엔티티의 물리적인 힘을 적용할 수 있도록 내부 호출(`InternalCall`)을 정의.

---

#### **2. `Vector3` 및 `Vector4` 구조체 수정**
- `Vector3.XY` 속성 변경  
  - 기존: `Vector2(X, Y);`
  - 변경: `Vector3(X, Y, 0);`
  - **변경 이유**: `XY` 값을 가져올 때 Z축이 포함되지 않는 문제를 해결하고, `Vector3` 형식으로 일관성을 유지함.

- `Vector4.XYZ` 속성 변경  
  - 기존: `Vector3(X, Y, Z);`
  - 변경: `Vector4(X, Y, Z, 0);`
  - **변경 이유**: `XYZ`를 `Vector4`로 확장하여 일관성을 유지함.

---

#### **3. `Rigidbody` 클래스 수정**
- `m_canSleep` 및 `m_isAwake` 속성 추가
  - **추가 이유**: 물리 엔진에서 객체의 수면 상태를 관리할 수 있도록 개선함.

---

#### **4. `Scene` 및 `ScriptGlue` 수정**
- `Scene::onComponentAdded<MeshRendererComponent>`에서 `BoxColliderComponent` 자동 추가 로직 제거.
  - **변경 이유**: `MeshRendererComponent`를 추가할 때 자동으로 `BoxColliderComponent`를 생성하는 로직을 제거하여 불필요한 충돌 컴포넌트가 추가되지 않도록 개선함.

- `ScriptGlue`에서 `Entity_hasComponent` 메서드 수정
  - 기존: `scene->createEntityWithUUID(entityID);`
  - 변경: `scene->getEntityByUUID(entityID);`
  - **변경 이유**: 새로운 엔티티를 생성하는 것이 아니라 기존 엔티티를 가져오도록 수정하여 버그 방지.

---

#### **5. `Player.cs` 스크립트 수정**
- `RigidbodyComponent` 추가 및 `addForce` 적용
  - 기존: `m_Transform` 만 사용
  - 변경: `m_Rigidbody`를 추가하여 `addForce`로 힘을 적용
  - **변경 이유**: 기존에는 `TransformComponent`를 직접 변경했으나, 이제 `RigidbodyComponent`를 통해 힘을 적용하는 방식으로 수정하여 물리 기반 움직임을 적용함.

---

#### **6. `EditorLayer.cpp` 코드 정리**
- `setDockingSpace()` 주석 처리 제거
- `ImGui::End();` 위치 정리
  - **변경 이유**: 코드 가독성을 높이고 불필요한 주석 제거.

---
