### PR TITLE
58 feat relationship component scene

### DIFF
--- a/AL/include/Scene/Entity.h
+++ b/AL/include/Scene/Entity.h
@@ -24,7 +24,9 @@ class Entity
 	template <typename T, typename... Args> T &addOrReplaceComponent(Args &&...args)
 	{
 		// ASSERT NOT HAS COMPONENT
-		return m_Scene->m_Registry.emplace_or_replace<T>(m_EntityHandle, std::forward<Args>(args)...);
+		T &component = m_Scene->m_Registry.emplace_or_replace<T>(m_EntityHandle, std::forward<Args>(args)...);
+		m_Scene->onComponentAdded<T>(*this, component);
+		return component;
 	}
 
 	template <typename T> T &getComponent()
@@ -40,14 +42,12 @@ class Entity
 	}
 
 	// 템플릿 완전 특수화
-	template <>
-	void removeComponent<MeshRendererComponent>()
+	template <> void removeComponent<MeshRendererComponent>()
 	{
 		auto &component = m_Scene->getComponent<MeshRendererComponent>(m_EntityHandle);
 		m_Scene->removeEntityInCullTree(component.nodeId);
 		m_Scene->m_Registry.remove<MeshRendererComponent>(m_EntityHandle);
 	}
-
 
 	template <typename T> bool hasComponent()
 	{

--- a/AL/include/Scene/Scene.h
+++ b/AL/include/Scene/Scene.h
@@ -9,6 +9,8 @@
 #include "Renderer/EditorCamera.h"
 #include "Renderer/Material.h"
 
+#include <queue>
+
 namespace ale
 {
 class Entity;
@@ -30,6 +32,8 @@ class Scene
 	Entity createEntity(const std::string &name = "");
 	Entity createEntityWithUUID(UUID uuid, const std::string &name = "");
 	void destroyEntity(Entity entity);
+	void insertDestroyEntity(Entity entity);
+	void destroyEntities();
 
 	void onRuntimeStart();
 	void onRuntimeStop();
@@ -37,6 +41,8 @@ class Scene
 	void onUpdateEditor(EditorCamera &camera);
 	void onUpdateRuntime(Timestep ts);
 	void onViewportResize(uint32_t width, uint32_t height);
+
+	Entity duplicateEntity(Entity entity);
 
 	void step(int32_t frames);
 
@@ -66,6 +72,19 @@ class Scene
 	{
 		return m_defaultMaterial;
 	}
+	std::shared_ptr<Model> &getBoxModel()
+	{
+		return m_boxModel;
+	}
+	std::shared_ptr<Model> &getSphereModel()
+	{
+		return m_sphereModel;
+	}
+	std::shared_ptr<Model> &getPlaneModel()
+	{
+		return m_planeModel;
+	}
+
 	std::shared_ptr<Model> getDefaultModel(int32_t idx);
 
 	Entity findEntityByName(std::string_view name);
@@ -112,6 +131,7 @@ class Scene
 	int32_t m_StepFrames = 0;
 
 	std::unordered_map<UUID, entt::entity> m_EntityMap;
+	std::queue<entt::entity> m_DestroyQueue;
 
 	DefaultTextures m_defaultTextures;
 	std::shared_ptr<Material> m_defaultMaterial;

--- a/AL/include/Scene/SceneSerializer.h
+++ b/AL/include/Scene/SceneSerializer.h
@@ -1,9 +1,17 @@
 #pragma once
 
 #include "Scene/Scene.h"
+#include <unordered_map>
 
 namespace ale
 {
+struct RelationshipData
+{
+	uint64_t entityUUID;
+	uint64_t parentUUID;
+	std::vector<uint64_t> childrenUUIDs;
+};
+
 class SceneSerializer
 {
   public:
@@ -17,6 +25,7 @@ class SceneSerializer
 
   private:
 	std::shared_ptr<Scene> m_Scene;
+	std::unordered_map<uint64_t, RelationshipData> relationshipMap;
 };
 
 } // namespace ale

--- a/AL/src/Renderer/VulkanContext.cpp
+++ b/AL/src/Renderer/VulkanContext.cpp
@@ -470,7 +470,7 @@ QueueFamilyIndices VulkanContext::findQueueFamilies(VkPhysicalDevice device)
 // 디스크립터 풀 생성
 void VulkanContext::createDescriptorPool()
 {
-	size_t MAX_OBJECTS = 1000;
+	size_t MAX_OBJECTS = 10000;
 
 	// 디스크립터 풀의 타입별 디스크립터 개수를 설정하는 구조체
 	std::array<VkDescriptorPoolSize, 5> poolSizes{};

--- a/Sandbox/Project/Assets/Scenes/Physics.ale
+++ b/Sandbox/Project/Assets/Scenes/Physics.ale
@@ -1,0 +1,369 @@
+Scene: Untitled
+Entities:
+  - Entity: 6293343376024623722
+    TagComponent:
+      Tag: Box_2_0_2
+    TransformComponent:
+      Position: [2, 0, 2]
+      Rotation: [0, 0, 0]
+      Scale: [1, 1, 1]
+    RelationshipComponent:
+      Parent: 0
+      Children:
+        []
+    MeshRendererComponent:
+      MeshType: 0
+    BoxColliderComponent:
+      Center: [0, 0, 0]
+      Size: [1, 1, 1]
+      IsTrigger: false
+  - Entity: 803444354161059500
+    TagComponent:
+      Tag: Box_2_0_0
+    TransformComponent:
+      Position: [2, 0, 1]
+      Rotation: [0, 0, 0]
+      Scale: [1, 1, 1]
+    RelationshipComponent:
+      Parent: 0
+      Children:
+        []
+    MeshRendererComponent:
+      MeshType: 0
+    BoxColliderComponent:
+      Center: [0, 0, 0]
+      Size: [1, 1, 1]
+      IsTrigger: false
+  - Entity: 5035355779366477212
+    TagComponent:
+      Tag: Box_2_0_1
+    TransformComponent:
+      Position: [2, 0, 0]
+      Rotation: [0, 0, 0]
+      Scale: [1, 1, 1]
+    RelationshipComponent:
+      Parent: 0
+      Children:
+        []
+    MeshRendererComponent:
+      MeshType: 0
+    BoxColliderComponent:
+      Center: [0, 0, 0]
+      Size: [1, 1, 1]
+      IsTrigger: false
+  - Entity: 14296718304309817607
+    TagComponent:
+      Tag: Box_1_0_2
+    TransformComponent:
+      Position: [1, 0, 2]
+      Rotation: [0, 0, 0]
+      Scale: [1, 1, 1]
+    RelationshipComponent:
+      Parent: 0
+      Children:
+        []
+    MeshRendererComponent:
+      MeshType: 0
+    BoxColliderComponent:
+      Center: [0, 0, 0]
+      Size: [1, 1, 1]
+      IsTrigger: false
+  - Entity: 8734110070815036263
+    TagComponent:
+      Tag: Box_1_0_0
+    TransformComponent:
+      Position: [1, 0, 0]
+      Rotation: [0, 0, 0]
+      Scale: [1, 1, 1]
+    RelationshipComponent:
+      Parent: 0
+      Children:
+        []
+    MeshRendererComponent:
+      MeshType: 0
+    BoxColliderComponent:
+      Center: [0, 0, 0]
+      Size: [1, 1, 1]
+      IsTrigger: false
+  - Entity: 15276963487207332527
+    TagComponent:
+      Tag: Box_1_0_1
+    TransformComponent:
+      Position: [1, 0, 1]
+      Rotation: [0, 0, 0]
+      Scale: [1, 1, 1]
+    RelationshipComponent:
+      Parent: 0
+      Children:
+        []
+    MeshRendererComponent:
+      MeshType: 0
+    BoxColliderComponent:
+      Center: [0, 0, 0]
+      Size: [1, 1, 1]
+      IsTrigger: false
+  - Entity: 10000000000000000009
+    TagComponent:
+      Tag: Box_0_2_2
+    TransformComponent:
+      Position: [0, 2, 2]
+      Rotation: [0, 0, 0]
+      Scale: [1, 1, 1]
+    RelationshipComponent:
+      Parent: 0
+      Children:
+        []
+    MeshRendererComponent:
+      MeshType: 0
+    BoxColliderComponent:
+      Center: [0, 0, 0]
+      Size: [1, 1, 1]
+      IsTrigger: false
+  - Entity: 10000000000000000008
+    TagComponent:
+      Tag: Box_0_2_1
+    TransformComponent:
+      Position: [0, 2, 1]
+      Rotation: [0, 0, 0]
+      Scale: [1, 1, 1]
+    RelationshipComponent:
+      Parent: 0
+      Children:
+        []
+    MeshRendererComponent:
+      MeshType: 0
+    BoxColliderComponent:
+      Center: [0, 0, 0]
+      Size: [1, 1, 1]
+      IsTrigger: false
+  - Entity: 10000000000000000007
+    TagComponent:
+      Tag: Box_0_2_0
+    TransformComponent:
+      Position: [0, 2, 0]
+      Rotation: [0, 0, 0]
+      Scale: [1, 1, 1]
+    RelationshipComponent:
+      Parent: 0
+      Children:
+        []
+    MeshRendererComponent:
+      MeshType: 0
+    BoxColliderComponent:
+      Center: [0, 0, 0]
+      Size: [1, 1, 1]
+      IsTrigger: false
+  - Entity: 10000000000000000006
+    TagComponent:
+      Tag: Box_0_1_2
+    TransformComponent:
+      Position: [0, 1, 2]
+      Rotation: [0, 0, 0]
+      Scale: [1, 1, 1]
+    RelationshipComponent:
+      Parent: 0
+      Children:
+        []
+    MeshRendererComponent:
+      MeshType: 0
+    BoxColliderComponent:
+      Center: [0, 0, 0]
+      Size: [1, 1, 1]
+      IsTrigger: false
+  - Entity: 10000000000000000005
+    TagComponent:
+      Tag: Box_0_1_1
+    TransformComponent:
+      Position: [0, 1, 1]
+      Rotation: [0, 0, 0]
+      Scale: [1, 1, 1]
+    RelationshipComponent:
+      Parent: 0
+      Children:
+        []
+    MeshRendererComponent:
+      MeshType: 0
+    BoxColliderComponent:
+      Center: [0, 0, 0]
+      Size: [1, 1, 1]
+      IsTrigger: false
+  - Entity: 10000000000000000004
+    TagComponent:
+      Tag: Box_0_1_0
+    TransformComponent:
+      Position: [0, 1, 0]
+      Rotation: [0, 0, 0]
+      Scale: [1, 1, 1]
+    RelationshipComponent:
+      Parent: 0
+      Children:
+        []
+    MeshRendererComponent:
+      MeshType: 0
+    BoxColliderComponent:
+      Center: [0, 0, 0]
+      Size: [1, 1, 1]
+      IsTrigger: false
+  - Entity: 10000000000000000003
+    TagComponent:
+      Tag: Box_0_0_2
+    TransformComponent:
+      Position: [0, 0, 2]
+      Rotation: [0, 0, 0]
+      Scale: [1, 1, 1]
+    RelationshipComponent:
+      Parent: 0
+      Children:
+        []
+    MeshRendererComponent:
+      MeshType: 0
+    BoxColliderComponent:
+      Center: [0, 0, 0]
+      Size: [1, 1, 1]
+      IsTrigger: false
+  - Entity: 10000000000000000002
+    TagComponent:
+      Tag: Box_0_0_1
+    TransformComponent:
+      Position: [0, 0, 1]
+      Rotation: [0, 0, 0]
+      Scale: [1, 1, 1]
+    RelationshipComponent:
+      Parent: 0
+      Children:
+        []
+    MeshRendererComponent:
+      MeshType: 0
+    BoxColliderComponent:
+      Center: [0, 0, 0]
+      Size: [1, 1, 1]
+      IsTrigger: false
+  - Entity: 10000000000000000001
+    TagComponent:
+      Tag: Box_0_0_0
+    TransformComponent:
+      Position: [0, 0, 0]
+      Rotation: [0, 0, 0]
+      Scale: [1, 1, 1]
+    RelationshipComponent:
+      Parent: 0
+      Children:
+        []
+    MeshRendererComponent:
+      MeshType: 0
+    BoxColliderComponent:
+      Center: [0, 0, 0]
+      Size: [1, 1, 1]
+      IsTrigger: false
+  - Entity: 606118099047227836
+    TagComponent:
+      Tag: Light
+    TransformComponent:
+      Position: [13.8000002, 0.5, 15.1000004]
+      Rotation: [0, 0, 0]
+      Scale: [1, 1, 1]
+    RelationshipComponent:
+      Parent: 0
+      Children:
+        []
+    LightComponent:
+      Type: 0
+      ShadowMap: 1
+      Position: [13.8000002, 0.5, 15.1000004]
+      Direction: [0, -1, 0]
+      Color: [1, 1, 1]
+      Intensity: 1
+      InnerCutoff: 0.976296008
+      OuterCutoff: 0.953716934
+  - Entity: 2187969428862952050
+    TagComponent:
+      Tag: Light
+    TransformComponent:
+      Position: [-0.200000003, 7.9000001, -0.100000001]
+      Rotation: [0, 0, 0]
+      Scale: [0.100000001, 0.100000001, 0.100000001]
+    RelationshipComponent:
+      Parent: 0
+      Children:
+        []
+    LightComponent:
+      Type: 0
+      ShadowMap: 1
+      Position: [-0.200000003, 7.9000001, -0.100000001]
+      Direction: [0, -1, 0]
+      Color: [1, 1, 1]
+      Intensity: 5.69999981
+      InnerCutoff: 0.976296008
+      OuterCutoff: 0.953716934
+  - Entity: 11822122333692858422
+    TagComponent:
+      Tag: Camera
+    TransformComponent:
+      Position: [0, 0, 20]
+      Rotation: [0, 0, 0]
+      Scale: [1, 1, 1]
+    RelationshipComponent:
+      Parent: 0
+      Children:
+        []
+    CameraComponent:
+      Camera:
+        PerspectiveFOV: 0.785398185
+        PerspectiveNear: 0.00999999978
+        PerspectiveFar: 100
+      Primary: true
+      FixedAspectRatio: false
+    ScriptComponent:
+      ClassName: Sandbox.Camera
+      ScriptFields:
+        - Name: RotSpeed
+          Type: Float
+          Data: 2
+        - Name: Speed
+          Type: Float
+          Data: 10
+  - Entity: 3619305722777497448
+    TagComponent:
+      Tag: Player
+    TransformComponent:
+      Position: [9.89999962, 0.899999976, 10]
+      Rotation: [0, 0, 0]
+      Scale: [1, 1, 1]
+    RelationshipComponent:
+      Parent: 0
+      Children:
+        []
+    MeshRendererComponent:
+      MeshType: 1
+    ScriptComponent:
+      ClassName: Sandbox.Player
+      ScriptFields:
+        - Name: Speed
+          Type: Float
+          Data: 100000
+    RigidbodyComponent:
+      Mass: 1
+      Drag: 0.00100000005
+      AngularDrag: 0.00100000005
+      UseGravity: false
+    SphereColliderComponent:
+      Center: [0, 0, 0]
+      Radius: 1
+      IsTrigger: false
+  - Entity: 10000000000000000001
+    TagComponent:
+      Tag: Plane
+    TransformComponent:
+      Position: [0, -0.5, 0]
+      Rotation: [-1.57079637, 0, 0]
+      Scale: [50, 50, 1]
+    RelationshipComponent:
+      Parent: 0
+      Children:
+        []
+    MeshRendererComponent:
+      MeshType: 2
+    BoxColliderComponent:
+      Center: [0, 0, 0]
+      Size: [1, 1, 1]
+      IsTrigger: false

--- a/Sandbox/src/EditorLayer.cpp
+++ b/Sandbox/src/EditorLayer.cpp
@@ -148,6 +148,12 @@ bool EditorLayer::onKeyPressed(KeyPressedEvent &e)
 				saveScene();
 		}
 		break;
+	case Key::D:
+		if (control)
+			duplicateEntity();
+		break;
+	case Key::Delete:
+		break;
 	case Key::Escape:
 		App::get().close();
 		break;
@@ -474,6 +480,19 @@ void EditorLayer::onSceneStop()
 	// loadSceneToRenderer(m_ActiveScene);
 
 	m_SceneHierarchyPanel.setContext(m_ActiveScene);
+}
+
+void EditorLayer::duplicateEntity()
+{
+	if (m_SceneState != ESceneState::EDIT)
+		return;
+
+	Entity selectedEntity = m_SceneHierarchyPanel.getSelectedEntity();
+	if (selectedEntity)
+	{
+		Entity newEntity = m_EditorScene->duplicateEntity(selectedEntity);
+		m_SceneHierarchyPanel.setSelectedEntity(newEntity);
+	}
 }
 
 void EditorLayer::loadSceneToRenderer(std::shared_ptr<Scene> &scene)

--- a/Sandbox/src/EditorLayer.h
+++ b/Sandbox/src/EditorLayer.h
@@ -52,6 +52,8 @@ class EditorLayer : public Layer
 	void onScenePause();
 	void onSceneStop();
 
+	void duplicateEntity();
+
 	void loadSceneToRenderer(std::shared_ptr<Scene> &scene);
 
   private:

--- a/Sandbox/src/Panel/SceneHierarchyPanel.h
+++ b/Sandbox/src/Panel/SceneHierarchyPanel.h
@@ -16,6 +16,13 @@ class SceneHierarchyPanel
 	void setContext(const std::shared_ptr<Scene> &context);
 	void onImGuiRender();
 
+	Entity getSelectedEntity() const
+	{
+		return m_SelectionContext;
+	}
+
+	void setSelectedEntity(Entity entity);
+
   private:
 	template <typename T> void displayAddComponentEntry(const std::string &entryName);
 


### PR DESCRIPTION
---

## **1. 씬(Scene) 클래스 기능 추가**
- **엔터티 삭제 대기열(`m_DestroyQueue`) 추가**  
  - `insertDestroyEntity(Entity entity)`: 삭제할 엔터티를 대기열에 추가.  
  - `destroyEntities()`: 대기열에 있는 모든 엔터티를 한 번에 삭제.  

- **씬의 기본 모델 관리 기능 추가**
  - `getBoxModel()`, `getSphereModel()`, `getPlaneModel()` 함수 추가.  
  - `getDefaultModel(int32_t idx)`: 기본 모델을 인덱스에 따라 반환하는 기능 추가.  

---

## **2. 씬 직렬화(Serialization) 개선**
- **`SceneSerializer` 개선 및 관계(Relationship) 정보 추가**  
  - 엔티티의 부모-자식 관계를 저장하는 `RelationshipData` 임시 구조체 추가.  
  - `serializeEntity()` 함수에서 **RelationshipComponent**를 포함하여 직렬화하도록 수정.  
  - `deserialize()` 과정에서 **1차로 관계 데이터 저장, 2차로 엔터티 간 연결을 복원하는 방식**으로 개선.

- **기본 모델 참조 방식 변경**  
  - 기존: `Model::createBoxModel()` 등으로 직접 모델 생성.  
  - 변경: `m_Scene->getBoxModel()` 등 씬 내부에서 관리하는 모델을 참조하도록 수정.

---

## **3. Vulkan 디스크립터 풀 크기 증가**
- `VulkanContext::createDescriptorPool()`  
  - 기존 `MAX_OBJECTS = 1000` → **`MAX_OBJECTS = 10000`**으로 증가.

---

## **4. Editor 기능 개선**
- **엔터티 복제 기능 (`duplicateEntity`) 추가**
  - `Ctrl + D` 키 입력 시 현재 선택된 엔터티를 복제.  
  - 복제된 엔터티를 `SceneHierarchyPanel`에서 자동 선택.

- **씬 계층 구조 패널(SceneHierarchyPanel) 개선**
  - `setSelectedEntity(Entity entity)`: 선택된 엔터티를 설정하는 기능 추가.   
  - `drawEntityNode()`: 엔터티 삭제 시 **삭제 대기열을 활용하도록 변경**하여 안정성을 향상.

- **UI 개선**
  - `ImGui::InputText("##Tag", buffer, sizeof(buffer))` →  
    `label.c_str()`을 사용하여 **각 엔터티마다 고유한 ID를 갖도록 변경**.

---

## **5. 물리 테스트 씬 추가 (`Physics.ale`)**
- 여러 개의 `Box` 엔터티와 `Light`, `Camera`, `Player` 엔터티가 포함된 물리 테스트 씬 추가.
- `Player`는 `RigidbodyComponent`, `SphereColliderComponent`, `ScriptComponent` 포함.

---
