### PR TITLE
[Feat]: Material UI added

### DIFF
--- a/AL/include/Scene/Component.h
+++ b/AL/include/Scene/Component.h
@@ -84,6 +84,8 @@ struct MeshRendererComponent
 	std::shared_ptr<RenderingComponent> m_RenderingComponent;
 	uint32_t type;
 	std::string path;
+
+	// Culling
 	int32_t nodeId;
 	CullSphere cullSphere;
 	bool renderEnabled;

--- a/Sandbox/src/Panel/SceneHierarchyPanel.cpp
+++ b/Sandbox/src/Panel/SceneHierarchyPanel.cpp
@@ -683,6 +683,34 @@ void SceneHierarchyPanel::drawComponents(Entity entity)
 			}
 			ImGui::EndDragDropTarget();
 		}
+		auto &materials = rc->getMaterials();
+
+		if (materials.size() != 1)
+		{
+			std::shared_ptr<Material> material = materials[1];
+			Albedo &albedo = material->getAlbedo();
+			drawVec3Control("Albedo", albedo.albedo);
+			drawCheckBox("Albedo Flag", albedo.flag);
+
+			NormalMap &normalMap = material->getNormalMap();
+			drawCheckBox("Normal Flag", normalMap.flag);
+
+			Roughness &roughness = material->getRoughness();
+			drawFloatControl("Roughness", roughness.roughness);
+			drawCheckBox("Roughness Flag", roughness.flag);
+
+			Metallic &metalic = material->getMetallic();
+			drawFloatControl("Metallic", metalic.metallic);
+			drawCheckBox("Metallic Flag", metalic.flag);
+
+			AOMap &aoMap = material->getAOMap();
+			drawFloatControl("AOMap", aoMap.ao);
+			drawCheckBox("AOMap Flag", aoMap.flag);
+
+			HeightMap &heightMap = material->getHeightMap();
+			drawFloatControl("HeightMap", heightMap.height);
+			drawCheckBox("HeightMap Flag", heightMap.flag);
+		}
 	});
 
 	drawComponent<LightComponent>("Light", entity, [entity, scene = m_Context](auto &component) mutable {


### PR DESCRIPTION
### 🔹 주요 변경 사항  
1. **재질(Material) 가져오기**  
   - `rc->getMaterials()`를 사용하여 재질 목록을 가져옴.  
   - 재질이 1개보다 많을 경우, `materials[1]`을 선택하여 작업 수행.  
   - 추후 index로 material 선택할 수 있게 수정.

2. **재질 속성 UI 추가**  
   - **Albedo** (기본 색상)  
     - `drawVec3Control("Albedo", albedo.albedo);` → RGB 값 조정  
     - `drawCheckBox("Albedo Flag", albedo.flag);` → 사용 여부 체크  

   - **NormalMap** (노멀 맵)  
     - `drawCheckBox("Normal Flag", normalMap.flag);` → 사용 여부 체크  

   - **Roughness** (거칠기)  
     - `drawFloatControl("Roughness", roughness.roughness);` → 값 조정  
     - `drawCheckBox("Roughness Flag", roughness.flag);` → 사용 여부 체크  

   - **Metallic** (금속성)  
     - `drawFloatControl("Metallic", metalic.metallic);` → 값 조정  
     - `drawCheckBox("Metallic Flag", metalic.flag);` → 사용 여부 체크  

   - **AOMap** (Ambient Occlusion 맵)  
     - `drawFloatControl("AOMap", aoMap.ao);` → 값 조정  
     - `drawCheckBox("AOMap Flag", aoMap.flag);` → 사용 여부 체크  

   - **HeightMap** (높이 맵)  
     - `drawFloatControl("HeightMap", heightMap.height);` → 값 조정  
     - `drawCheckBox("HeightMap Flag", heightMap.flag);` → 사용 여부 체크  
