### PR TITLE
72 feat add 3d object

### DIFF
--- a/AL/include/Renderer/Mesh.h
+++ b/AL/include/Renderer/Mesh.h
@@ -15,6 +15,8 @@ class Mesh
 	static std::shared_ptr<Mesh> createSphere();
 	static std::shared_ptr<Mesh> createPlane();
 	static std::shared_ptr<Mesh> createGround();
+	static std::shared_ptr<Mesh> createCapsule();
+	static std::shared_ptr<Mesh> createCylinder();
 
 	~Mesh() = default;
 

--- a/AL/include/Renderer/Model.h
+++ b/AL/include/Renderer/Model.h
@@ -3,10 +3,10 @@
 
 #include "Core/Base.h"
 
+#include "Renderer/Animation/SkeletalAnimations.h"
 #include "Renderer/Common.h"
 #include "Renderer/Material.h"
 #include "Renderer/Mesh.h"
-#include "Renderer/Animation/SkeletalAnimations.h"
 #include "Renderer/OBJLoader.h"
 
 #include <assimp/Importer.hpp>
@@ -17,12 +17,13 @@ namespace ale
 {
 class ShaderResourceManager;
 
-struct DrawInfo {
+struct DrawInfo
+{
 	glm::mat4 model;
 	glm::mat4 view;
 	glm::mat4 projection;
 	glm::mat4 finalBonesMatrices[MAX_BONES];
-	ShaderResourceManager* shaderResourceManager;
+	ShaderResourceManager *shaderResourceManager;
 	VkCommandBuffer commandBuffer;
 	VkPipelineLayout pipelineLayout;
 	std::vector<std::shared_ptr<Material>> materials;
@@ -61,6 +62,8 @@ class Model
 	static std::shared_ptr<Model> createSphereModel(std::shared_ptr<Material> &defaultMaterial);
 	static std::shared_ptr<Model> createPlaneModel(std::shared_ptr<Material> &defaultMaterial);
 	static std::shared_ptr<Model> createGroundModel(std::shared_ptr<Material> &defaultMaterial);
+	static std::shared_ptr<Model> createCapsuleModel(std::shared_ptr<Material> &defaultMaterial);
+	static std::shared_ptr<Model> createCylinderModel(std::shared_ptr<Material> &defaultMaterial);
 
 	~Model() = default;
 	void cleanup();
@@ -83,10 +86,11 @@ class Model
 		return m_materials;
 	}
 	void updateMaterial(std::vector<std::shared_ptr<Material>> materials);
-  void updateAnimations(SkeletalAnimation* animation, const Timestep& timestep, uint32_t prevImage, uint32_t currentImage);
-	void setShaderData(const std::vector<glm::mat4>& shaderData);
-	std::shared_ptr<SkeletalAnimations>& getAnimations();
-	std::shared_ptr<Armature::Skeleton>& getSkeleton();
+	void updateAnimations(SkeletalAnimation *animation, const Timestep &timestep, uint32_t prevImage,
+						  uint32_t currentImage);
+	void setShaderData(const std::vector<glm::mat4> &shaderData);
+	std::shared_ptr<SkeletalAnimations> &getAnimations();
+	std::shared_ptr<Armature::Skeleton> &getSkeleton();
 	bool m_SkeletalAnimations;
 
   private:
@@ -94,7 +98,7 @@ class Model
 
 	std::vector<std::shared_ptr<Mesh>> m_meshes;
 	std::vector<std::shared_ptr<Material>> m_materials;
-  
+
 	// animation
 	std::shared_ptr<SkeletalAnimations> m_Animations;
 	std::shared_ptr<Armature::Skeleton> m_Skeleton;
@@ -110,6 +114,9 @@ class Model
 	void initSphereModel(std::shared_ptr<Material> &defaultMaterial);
 	void initPlaneModel(std::shared_ptr<Material> &defaultMaterial);
 	void initGroundModel(std::shared_ptr<Material> &defaultMaterial);
+	void initCapsuleModel(std::shared_ptr<Material> &defaultMaterial);
+	void initCylinderModel(std::shared_ptr<Material> &defaultMaterial);
+
 	void loadModel(std::string path, std::shared_ptr<Material> &defaultMaterial);
 	void loadGLTFModel(std::string path, std::shared_ptr<Material> &defaultMaterial);
 	void loadOBJModel(std::string path, std::shared_ptr<Material> &defaultMaterial);
@@ -124,13 +131,13 @@ class Model
 
 	std::shared_ptr<Texture> loadMaterialTexture(const aiScene *scene, aiMaterial *material, std::string path,
 												 aiString texturePath);
-  void processOBJNode(aiNode *node, const aiScene *scene, std::shared_ptr<Material> &defaultMaterial);
-  void processGLTFSkeleton(const aiScene* scene);
-	void collectAllBones(const aiScene* scene, std::vector<aiBone*>& outBones);
-	void buildSkeletonBoneArray(const std::vector<aiBone*>& allAiBones);
-	void loadBone(aiNode* node, int parentBoneIndex);
-	void loadAnimations(const aiScene* scene);
-	glm::mat4 convertMatrix(const aiMatrix4x4& m);
+	void processOBJNode(aiNode *node, const aiScene *scene, std::shared_ptr<Material> &defaultMaterial);
+	void processGLTFSkeleton(const aiScene *scene);
+	void collectAllBones(const aiScene *scene, std::vector<aiBone *> &outBones);
+	void buildSkeletonBoneArray(const std::vector<aiBone *> &allAiBones);
+	void loadBone(aiNode *node, int parentBoneIndex);
+	void loadAnimations(const aiScene *scene);
+	glm::mat4 convertMatrix(const aiMatrix4x4 &m);
 };
 
 } // namespace ale

--- a/AL/include/Scene/Scene.h
+++ b/AL/include/Scene/Scene.h
@@ -35,6 +35,8 @@ class Scene
 	void insertDestroyEntity(Entity entity);
 	void destroyEntities();
 
+	Entity createPrimitiveMeshEntity(const std::string &name, uint32_t idx);
+
 	void onRuntimeStart();
 	void onRuntimeStop();
 
@@ -87,6 +89,14 @@ class Scene
 	std::shared_ptr<Model> &getGroundModel()
 	{
 		return m_groundModel;
+	}
+	std::shared_ptr<Model> &getCapsuleModel()
+	{
+		return m_capsuleModel;
+	}
+	std::shared_ptr<Model> &getCylinderModel()
+	{
+		return m_cylinderModel;
 	}
 
 	std::shared_ptr<Model> getDefaultModel(int32_t idx);
@@ -143,6 +153,8 @@ class Scene
 	std::shared_ptr<Model> m_sphereModel;
 	std::shared_ptr<Model> m_planeModel;
 	std::shared_ptr<Model> m_groundModel;
+	std::shared_ptr<Model> m_capsuleModel;
+	std::shared_ptr<Model> m_cylinderModel;
 
 	World *m_World = nullptr;
 

--- a/AL/src/Renderer/Mesh.cpp
+++ b/AL/src/Renderer/Mesh.cpp
@@ -129,6 +129,153 @@ std::shared_ptr<Mesh> Mesh::createGround()
 	return createMesh(vertices, indices);
 }
 
+std::shared_ptr<Mesh> Mesh::createCapsule()
+{
+	std::vector<Vertex> vertices;
+	std::vector<uint32_t> indices;
+	uint32_t halfLatiSegmentCount = 8;
+	uint32_t latiSegmentCount = halfLatiSegmentCount * 2;
+	uint32_t longiSegmentCount = 20;
+	float radius = 0.5f;
+
+	uint32_t circleVertCount = longiSegmentCount + 1;
+	vertices.resize((halfLatiSegmentCount + 1) * circleVertCount * 2);
+
+	glm::vec3 moveVector(0.0f, -radius, 0.0f);
+	for (uint32_t i = 0; i <= halfLatiSegmentCount; i++)
+	{
+		float v = (float)i / (float)latiSegmentCount;
+		float phi = (v - 0.5f) * glm::pi<float>();
+		auto cosPhi = cosf(phi);
+		auto sinPhi = sinf(phi);
+		for (uint32_t j = 0; j <= longiSegmentCount; j++)
+		{
+			float u = (float)j / (float)longiSegmentCount;
+			float theta = u * glm::pi<float>() * 2.0f;
+			auto cosTheta = cosf(theta);
+			auto sinTheta = sinf(theta);
+			auto point = glm::vec3(cosPhi * cosTheta, sinPhi, -cosPhi * sinTheta);
+
+			vertices[i * circleVertCount + j] = Vertex{point * radius + moveVector, point, glm::vec2(u, v)};
+		}
+	}
+
+	moveVector = -moveVector;
+	for (uint32_t i = halfLatiSegmentCount; i <= latiSegmentCount; i++)
+	{
+		float v = (float)i / (float)latiSegmentCount;
+		float phi = (v - 0.5f) * glm::pi<float>();
+		auto cosPhi = cosf(phi);
+		auto sinPhi = sinf(phi);
+		for (uint32_t j = 0; j <= longiSegmentCount; j++)
+		{
+			float u = (float)j / (float)longiSegmentCount;
+			float theta = u * glm::pi<float>() * 2.0f;
+			auto cosTheta = cosf(theta);
+			auto sinTheta = sinf(theta);
+			auto point = glm::vec3(cosPhi * cosTheta, sinPhi, -cosPhi * sinTheta);
+
+			vertices[(i + 1) * circleVertCount + j] = Vertex{point * radius + moveVector, point, glm::vec2(u, v)};
+		}
+	}
+
+	indices.resize((latiSegmentCount + 1) * longiSegmentCount * 6);
+	for (uint32_t i = 0; i <= latiSegmentCount; i++)
+	{
+		for (uint32_t j = 0; j < longiSegmentCount; j++)
+		{
+			uint32_t vertexOffset = i * circleVertCount + j;
+			uint32_t indexOffset = (i * longiSegmentCount + j) * 6;
+			indices[indexOffset] = vertexOffset;
+			indices[indexOffset + 1] = vertexOffset + 1;
+			indices[indexOffset + 2] = vertexOffset + 1 + circleVertCount;
+			indices[indexOffset + 3] = vertexOffset;
+			indices[indexOffset + 4] = vertexOffset + 1 + circleVertCount;
+			indices[indexOffset + 5] = vertexOffset + circleVertCount;
+		}
+	}
+
+	return createMesh(vertices, indices);
+}
+
+std::shared_ptr<Mesh> Mesh::createCylinder()
+{
+	std::vector<Vertex> vertices;
+
+	int32_t segments = 20.0f;
+	float halfHeight = 0.5f;
+	float radius = 0.5f;
+
+	float angleStep = 2.0f * glm::pi<float>() / static_cast<float>(segments);
+
+	// Top cap center
+	glm::vec3 topCenter(0.0f, halfHeight, 0.0f);
+	vertices.push_back({topCenter, glm::vec3(0.0f, 1.0f, 0.0f), glm::vec2(0.5f, 0.5f)});
+
+	// Top cap vertices
+	for (int32_t i = 0; i <= segments; ++i)
+	{
+		float theta = i * angleStep;
+		glm::vec3 position(radius * cos(theta), halfHeight, radius * sin(theta));
+		glm::vec2 texCoord(0.5f + 0.5f * cos(theta), 0.5f + 0.5f * sin(theta));
+		vertices.push_back({position, glm::vec3(0.0f, 1.0f, 0.0f), texCoord});
+	}
+
+	// Bottom cap center
+	glm::vec3 bottomCenter(0.0f, -halfHeight, 0.0f);
+	vertices.push_back({bottomCenter, glm::vec3(0.0f, -1.0f, 0.0f), glm::vec2(0.5f, 0.5f)});
+
+	// Bottom cap vertices
+	for (int32_t i = 0; i <= segments; ++i)
+	{
+		float theta = i * angleStep;
+		glm::vec3 position(radius * cos(theta), -halfHeight, radius * sin(theta));
+		glm::vec2 texCoord(0.5f + 0.5f * cos(theta), 0.5f + 0.5f * sin(theta));
+		vertices.push_back({position, glm::vec3(0.0f, -1.0f, 0.0f), texCoord});
+	}
+
+	std::vector<uint32_t> indices;
+
+	// Top cap indices
+	uint32_t topCenterIndex = 0;
+	for (int32_t i = 1; i <= segments; ++i)
+	{
+		indices.push_back(topCenterIndex);
+		indices.push_back(i + 1);
+		indices.push_back(i);
+	}
+
+	// Bottom cap indices
+	uint32_t bottomCenterIndex = segments + 2;
+	for (int32_t i = 1; i <= segments; ++i)
+	{
+		indices.push_back(bottomCenterIndex);
+		indices.push_back(bottomCenterIndex + i);
+		indices.push_back(bottomCenterIndex + i + 1);
+	}
+
+	// Side indices
+	for (int32_t i = 1; i <= segments; ++i)
+	{
+		uint32_t top1 = topCenterIndex + i;
+		uint32_t top2 = topCenterIndex + i + 1;
+		uint32_t bottom1 = bottomCenterIndex + i;
+		uint32_t bottom2 = bottomCenterIndex + i + 1;
+
+		// First triangle
+		indices.push_back(top1);
+		indices.push_back(bottom2);
+		indices.push_back(bottom1);
+
+		// Second triangle
+		indices.push_back(bottom2);
+		indices.push_back(top1);
+		indices.push_back(top2);
+	}
+
+	return createMesh(vertices, indices);
+}
+
 void Mesh::cleanup()
 {
 	m_vertexBuffer->cleanup();

--- a/AL/src/Scene/Scene.cpp
+++ b/AL/src/Scene/Scene.cpp
@@ -172,6 +172,18 @@ void Scene::destroyEntity(Entity entity)
 	m_Registry.destroy(entity);
 }
 
+Entity Scene::createPrimitiveMeshEntity(const std::string &name, uint32_t idx)
+{
+	Entity entity = createEntity(name);
+
+	auto &mc = entity.addComponent<MeshRendererComponent>();
+	std::shared_ptr<Model> &model = getDefaultModel(idx);
+
+	mc.type = idx;
+	mc.m_RenderingComponent = RenderingComponent::createRenderingComponent(model);
+	return entity;
+}
+
 void Scene::onRuntimeStart()
 {
 	m_IsRunning = true;
@@ -339,6 +351,8 @@ void Scene::initScene()
 	m_sphereModel = Model::createSphereModel(m_defaultMaterial);
 	m_planeModel = Model::createPlaneModel(m_defaultMaterial);
 	m_groundModel = Model::createGroundModel(m_defaultMaterial);
+	m_capsuleModel = Model::createCapsuleModel(m_defaultMaterial);
+	m_cylinderModel = Model::createCylinderModel(m_defaultMaterial);
 
 	m_cullTree.setScene(this);
 }
@@ -514,14 +528,18 @@ std::shared_ptr<Model> Scene::getDefaultModel(int32_t idx)
 	// ASSERT idx
 	switch (idx)
 	{
-	case 0:
-		return m_boxModel;
 	case 1:
-		return m_sphereModel;
+		return m_boxModel;
 	case 2:
-		return m_planeModel;
+		return m_sphereModel;
 	case 3:
+		return m_planeModel;
+	case 4:
 		return m_groundModel;
+	case 5:
+		return m_capsuleModel;
+	case 6:
+		return m_cylinderModel;
 	default:
 		return nullptr;
 	}
@@ -608,9 +626,8 @@ template <> void Scene::onComponentAdded<CameraComponent>(Entity entity, CameraC
 
 template <> void Scene::onComponentAdded<MeshRendererComponent>(Entity entity, MeshRendererComponent &component)
 {
-	component.type = 0;
-	component.m_RenderingComponent =
-		RenderingComponent::createRenderingComponent(Model::createBoxModel(this->getDefaultMaterial()));
+	component.type = 1;
+	component.m_RenderingComponent = RenderingComponent::createRenderingComponent(getBoxModel());
 	component.cullSphere = component.m_RenderingComponent->getCullSphere();
 
 	TransformComponent &transformComponent = getComponent<TransformComponent>(entity);
@@ -620,7 +637,6 @@ template <> void Scene::onComponentAdded<MeshRendererComponent>(Entity entity, M
 
 	// cullTree에 추가 sphere
 	component.nodeId = insertEntityInCullTree(sphere, entity);
-	// auto &bc = entity.addComponent<BoxColliderComponent>();
 }
 
 template <> void Scene::onComponentAdded<ModelComponent>(Entity entity, ModelComponent &component)

--- a/AL/src/Scene/SceneSerializer.cpp
+++ b/AL/src/Scene/SceneSerializer.cpp
@@ -499,21 +499,26 @@ bool SceneSerializer::deserialize(const std::string &filepath)
 				std::shared_ptr<Model> model;
 				switch (mc.type)
 				{
-				case 0:
+				case 1:
 					model = m_Scene->getBoxModel();
 					break;
-				case 1:
+				case 2:
 					model = m_Scene->getSphereModel();
 					break;
-				case 2:
+				case 3:
 					model = m_Scene->getPlaneModel();
 					break;
-				case 3:
+				case 4:
 					model = m_Scene->getGroundModel();
 					break;
 				case 5:
+					model = m_Scene->getCapsuleModel();
+					break;
+				case 6:
+					model = m_Scene->getCylinderModel();
+					break;
+				case 7:
 					mc.path = meshComponent["Path"].as<std::string>();
-					AL_CORE_TRACE("{}", mc.path);
 					model = Model::createModel(mc.path, m_Scene->getDefaultMaterial());
 					break;
 				// 그 외의 이상한 값은 box로 임의로 처리

--- a/Sandbox/src/Panel/SceneHierarchyPanel.cpp
+++ b/Sandbox/src/Panel/SceneHierarchyPanel.cpp
@@ -81,13 +81,17 @@ void SceneHierarchyPanel::onImGuiRender()
 			if (ImGui::BeginMenu("3D Object"))
 			{
 				if (ImGui::MenuItem("Box"))
-					;
+					m_Context->createPrimitiveMeshEntity("Box", 1);
 				if (ImGui::MenuItem("Sphere"))
-					;
+					m_Context->createPrimitiveMeshEntity("Sphere", 2);
+				if (ImGui::MenuItem("Plane"))
+					m_Context->createPrimitiveMeshEntity("Plane", 3);
+				if (ImGui::MenuItem("Ground"))
+					m_Context->createPrimitiveMeshEntity("Ground", 4);
 				if (ImGui::MenuItem("Capsule"))
-					;
+					m_Context->createPrimitiveMeshEntity("Capsule", 5);
 				if (ImGui::MenuItem("Cylinder"))
-					;
+					m_Context->createPrimitiveMeshEntity("Cylinder", 6);
 				ImGui::EndMenu();
 			}
 			ImGui::EndPopup();
@@ -644,7 +648,7 @@ void SceneHierarchyPanel::drawComponents(Entity entity)
 		uint32_t meshType = component.type;
 		std::shared_ptr<RenderingComponent> rc = component.m_RenderingComponent;
 
-		const char *meshTypeStrings[] = {"Box", "Sphere", "Plane", "Ground", "None", "Model"};
+		const char *meshTypeStrings[] = {"None", "Box", "Sphere", "Plane", "Ground", "Capsule", "Cylinder", "Model"};
 		const char *currentMeshTypeString = meshTypeStrings[(int)meshType];
 
 		ImGui::Columns(2);
@@ -654,7 +658,7 @@ void SceneHierarchyPanel::drawComponents(Entity entity)
 		ImGui::NextColumn();
 		if (ImGui::BeginCombo("##MeshTypeCombo", currentMeshTypeString))
 		{
-			for (int32_t i = 0; i < 6; ++i)
+			for (int32_t i = 0; i < 8; ++i)
 			{
 				bool isSelected = currentMeshTypeString == meshTypeStrings[i];
 
@@ -664,8 +668,12 @@ void SceneHierarchyPanel::drawComponents(Entity entity)
 					// model 정보 바꾸기
 
 					component.type = i;
-					if (i == 4) // None
+					if (i == 0) // None
 					{
+					}
+					else if (i == 7)
+					{
+						break;
 					}
 					else
 					{
@@ -699,7 +707,7 @@ void SceneHierarchyPanel::drawComponents(Entity entity)
 				{
 					std::shared_ptr<Model> model = Model::createModel(filePath.string(), scene->getDefaultMaterial());
 					component.m_RenderingComponent = RenderingComponent::createRenderingComponent(model);
-					component.type = 5;
+					component.type = 7;
 					component.path = filePath.string();
 					component.isMatChanged = false;
 				}
@@ -716,10 +724,6 @@ void SceneHierarchyPanel::drawComponents(Entity entity)
 				if (filePath.extension().string() == ".gltf" || filePath.extension().string() == ".glb" ||
 					filePath.extension().string() == ".obj")
 				{
-					// std::shared_ptr<Model> model = Model::createModel(filePath.string(),
-					// scene->getDefaultMaterial()); component.m_RenderingComponent =
-					// RenderingComponent::createRenderingComponent(model);
-
 					component.m_RenderingComponent->updateMaterial(
 						Model::createModel(filePath.string(), scene->getDefaultMaterial()));
 					component.matPath = filePath.string();


### PR DESCRIPTION
### **주요 변경 사항**  

#### 1️⃣ **MeshRendererComponent 개선**  
- 새로운 기본 메쉬 타입 추가:  
  - `Capsule (5)`, `Cylinder (6)`, `Model (7)`
- `Scene::onComponentAdded<MeshRendererComponent>()` 수정  
  - `cullSphere`을 `m_RenderingComponent`에서 가져와 적용하도록 개선  
  - `nodeId`를 `cullTree`에 추가하는 로직 유지  

#### 2️⃣ **SceneSerializer 개선 (직렬화 및 역직렬화 수정)**  
- `deserialize()`에서 `MeshType`별 모델 생성 로직 업데이트  
  - 새로운 `Capsule (5)`, `Cylinder (6)`, `Model (7)`에 대한 처리 추가  
  - `Model (7)`의 경우, `path`를 활용하여 모델 생성  
  - 정의되지 않은 `MeshType`은 기본적으로 `Box (1)`으로 처리  

#### 3️⃣ **SceneHierarchyPanel 개선 (UI 및 3D 객체 생성 기능 추가)**  
- **새로운 3D 객체 추가 지원**  
  - `Capsule` 및 `Cylinder` 추가  
  - `3D Object` 메뉴에서 선택 시 `createPrimitiveMeshEntity()`를 호출하여 엔터티 생성  
- **MeshType UI 변경**  
  - 기존: `{"Box", "Sphere", "Plane", "Ground", "None", "Model"}`
  - 변경: `{"None", "Box", "Sphere", "Plane", "Ground", "Capsule", "Cylinder", "Model"}`  
- **MeshType 선택 로직 수정**  
  - `None (0)` 선택 시 아무 변경 없음  
  - `Model (7)` 선택 시 기존 모델 생성 코드 유지  
  - `Capsule (5)`, `Cylinder (6)` 추가로 `for` 루프를 `6 → 8`로 확장  
