### PR TITLE
[Feat]: Add Vulkan resource cleanup logic and fix memory leaks

### DIFF
--- a/AL/include/Core/LayerStack.h
+++ b/AL/include/Core/LayerStack.h
@@ -18,6 +18,7 @@ class LayerStack
 	void pushOverlay(Layer *overlay);
 	void popLayer(Layer *layer);
 	void popOverlay(Layer *overlay);
+	void onDetach();
 
 	std::vector<Layer *>::iterator begin()
 	{

--- a/AL/include/Renderer/Material.h
+++ b/AL/include/Renderer/Material.h
@@ -55,6 +55,8 @@ class Material
 
 	~Material() = default;
 
+	void cleanup();
+
 	Albedo &getAlbedo()
 	{
 		return m_albedo;

--- a/AL/include/Renderer/Renderer.h
+++ b/AL/include/Renderer/Renderer.h
@@ -118,10 +118,6 @@ class Renderer
 	// Descriptor Pool
 	VkDescriptorPool descriptorPool;
 
-	std::unique_ptr<ShaderResourceManager> m_geometryPassShaderResourceManager;
-	std::vector<VkDescriptorSet> geometryPassDescriptorSets;
-	std::vector<std::shared_ptr<UniformBuffer>> geometryPassUniformBuffers;
-
 	std::unique_ptr<ShaderResourceManager> m_lightingPassShaderResourceManager;
 	std::vector<VkDescriptorSet> lightingPassDescriptorSets;
 	std::vector<std::shared_ptr<UniformBuffer>> lightingPassUniformBuffers;

--- a/AL/include/Renderer/RenderingComponent.h
+++ b/AL/include/Renderer/RenderingComponent.h
@@ -22,6 +22,8 @@ class RenderingComponent
 	void updateMaterial(std::vector<std::shared_ptr<Material>> materials);
 	void updateMaterial(std::shared_ptr<Model> model);
 
+	void cleanup();
+
 	CullSphere getCullSphere();
 
 	std::vector<std::shared_ptr<Material>> &getMaterials()

--- a/AL/include/Renderer/VulkanUtil.h
+++ b/AL/include/Renderer/VulkanUtil.h
@@ -40,6 +40,11 @@ class VulkanUtil
 								   VkDeviceMemory &imageMemory);
 	static VkImageView createCubeMapImageView(VkImage image, VkFormat format, VkImageAspectFlags aspectFlags,
 											  uint32_t mipLevels);
+
+	static VkDescriptorSetLayout createIconDescriptorSetLayout(VkDevice device, VkDescriptorPool descriptorPool);
+	static VkDescriptorSet createIconDescriptorSet(VkDevice device, VkDescriptorPool descriptorPool,
+												   VkDescriptorSetLayout descriptorSetLayout, VkImageView imageView,
+												   VkSampler sampler);
 };
 } // namespace ale
 

--- a/AL/include/Scene/Scene.h
+++ b/AL/include/Scene/Scene.h
@@ -35,6 +35,8 @@ class Scene
 	void insertDestroyEntity(Entity entity);
 	void destroyEntities();
 
+	void cleanup();
+
 	Entity createPrimitiveMeshEntity(const std::string &name, uint32_t idx);
 
 	void onRuntimeStart();

--- a/AL/src/Core/App.cpp
+++ b/AL/src/Core/App.cpp
@@ -36,6 +36,8 @@ App::App(const ApplicationSpecification &spec) : m_Spec(spec)
 App::~App()
 {
 	ScriptingEngine::shutDown();
+	m_LayerStack.onDetach();
+	m_Renderer->cleanup();
 }
 
 void App::pushLayer(Layer *layer)

--- a/AL/src/Core/LayerStack.cpp
+++ b/AL/src/Core/LayerStack.cpp
@@ -4,6 +4,15 @@ namespace ale
 {
 LayerStack::~LayerStack()
 {
+	// for (Layer *layer : m_Layers)
+	// {
+	// 	layer->onDetach();
+	// delete layer;
+	// }
+}
+
+void LayerStack::onDetach()
+{
 	for (Layer *layer : m_Layers)
 	{
 		layer->onDetach();

--- a/AL/src/Renderer/Buffer.cpp
+++ b/AL/src/Renderer/Buffer.cpp
@@ -111,8 +111,16 @@ std::unique_ptr<VertexBuffer> VertexBuffer::createVertexBuffer(std::vector<Verte
 
 void VertexBuffer::cleanup()
 {
-	vkDestroyBuffer(m_device, m_buffer, nullptr);
-	vkFreeMemory(m_device, m_bufferMemory, nullptr);
+	if (m_buffer != VK_NULL_HANDLE)
+	{
+		vkDestroyBuffer(m_device, m_buffer, nullptr);
+		m_buffer = VK_NULL_HANDLE;
+	}
+	if (m_bufferMemory != VK_NULL_HANDLE)
+	{
+		vkFreeMemory(m_device, m_bufferMemory, nullptr);
+		m_bufferMemory = VK_NULL_HANDLE;
+	}
 }
 
 void VertexBuffer::bind(VkCommandBuffer commandBuffer)
@@ -161,8 +169,16 @@ std::unique_ptr<IndexBuffer> IndexBuffer::createIndexBuffer(std::vector<uint32_t
 
 void IndexBuffer::cleanup()
 {
-	vkDestroyBuffer(m_device, m_buffer, nullptr);
-	vkFreeMemory(m_device, m_bufferMemory, nullptr);
+	if (m_buffer != VK_NULL_HANDLE)
+	{
+		vkDestroyBuffer(m_device, m_buffer, nullptr);
+		m_buffer = VK_NULL_HANDLE;
+	}
+	if (m_bufferMemory != VK_NULL_HANDLE)
+	{
+		vkFreeMemory(m_device, m_bufferMemory, nullptr);
+		m_bufferMemory = VK_NULL_HANDLE;
+	}
 }
 
 void IndexBuffer::bind(VkCommandBuffer commandBuffer)
@@ -229,8 +245,16 @@ std::unique_ptr<ImageBuffer> ImageBuffer::createImageBufferFromMemory(const aiTe
 
 void ImageBuffer::cleanup()
 {
-	vkDestroyImage(m_device, textureImage, nullptr);
-	vkFreeMemory(m_device, textureImageMemory, nullptr);
+	if (textureImage != VK_NULL_HANDLE)
+	{
+		vkDestroyImage(m_device, textureImage, nullptr);
+		textureImage = VK_NULL_HANDLE;
+	}
+	if (textureImageMemory != VK_NULL_HANDLE)
+	{
+		vkFreeMemory(m_device, textureImageMemory, nullptr);
+		textureImageMemory = VK_NULL_HANDLE;
+	}
 }
 
 bool ImageBuffer::initImageBuffer(std::string path, bool flipVertically)
@@ -677,8 +701,16 @@ std::shared_ptr<UniformBuffer> UniformBuffer::createUniformBuffer(VkDeviceSize b
 
 void UniformBuffer::cleanup()
 {
-	vkDestroyBuffer(m_device, m_buffer, nullptr);
-	vkFreeMemory(m_device, m_bufferMemory, nullptr);
+	if (m_buffer != VK_NULL_HANDLE)
+	{
+		vkDestroyBuffer(m_device, m_buffer, nullptr);
+		m_buffer = VK_NULL_HANDLE;
+	}
+	if (m_bufferMemory != VK_NULL_HANDLE)
+	{
+		vkFreeMemory(m_device, m_bufferMemory, nullptr);
+		m_bufferMemory = VK_NULL_HANDLE;
+	}
 }
 
 void UniformBuffer::updateUniformBuffer(void *data, VkDeviceSize size)

--- a/AL/src/Renderer/Material.cpp
+++ b/AL/src/Renderer/Material.cpp
@@ -20,4 +20,14 @@ void Material::initMaterial(Albedo albedo, NormalMap normalMap, Roughness roughn
 	m_aoMap = aoMap;
 	m_heightMap = heightMap;
 }
+
+void Material::cleanup()
+{
+	m_albedo.albedoTexture->cleanup();
+	m_normalMap.normalTexture->cleanup();
+	m_roughness.roughnessTexture->cleanup();
+	m_metallic.metallicTexture->cleanup();
+	m_aoMap.aoTexture->cleanup();
+	m_heightMap.heightTexture->cleanup();
+}
 } // namespace ale

--- a/AL/src/Renderer/Model.cpp
+++ b/AL/src/Renderer/Model.cpp
@@ -110,6 +110,10 @@ void Model::cleanup()
 	{
 		mesh->cleanup();
 	}
+	for (auto &material : m_materials)
+	{
+		material->cleanup();
+	}
 }
 
 void Model::draw(DrawInfo &drawInfo)
@@ -984,7 +988,6 @@ void Model::loadOBJModel(std::string path, std::shared_ptr<Material> &defaultMat
 	auto &mtlMap = objLoader->getMtlMap();
 	for (auto &map : subMeshMap)
 	{
-		std::cout << "Submesh: " << map.first << std::endl;
 		auto &subMesh = map.second;
 		auto &vertices = subMesh.vertices;
 		auto &indices = subMesh.indices;

--- a/AL/src/Renderer/RenderingComponent.cpp
+++ b/AL/src/Renderer/RenderingComponent.cpp
@@ -69,4 +69,22 @@ CullSphere RenderingComponent::getCullSphere()
 	return m_model->initCullSphere();
 }
 
+void RenderingComponent::cleanup()
+{
+	// m_model->cleanup();
+	m_shaderResourceManager->cleanup();
+	for (size_t i = 0; i < 4; i++)
+	{
+		m_shadowMapResourceManager[i]->cleanup();
+	}
+	for (size_t i = 0; i < 4; i++)
+	{
+		m_shadowCubeMapResourceManager[i]->cleanup();
+	}
+	// for (size_t i = 0; i < m_materials.size(); i++)
+	// {
+	// 	m_materials[i]->cleanup();
+	// }
+}
+
 } // namespace ale

--- a/AL/src/Renderer/Texture.cpp
+++ b/AL/src/Renderer/Texture.cpp
@@ -22,8 +22,16 @@ void Texture::cleanup()
 	auto &context = VulkanContext::getContext();
 	auto device = context.getDevice();
 
-	vkDestroySampler(device, textureSampler, nullptr);
-	vkDestroyImageView(device, textureImageView, nullptr);
+	if (textureSampler != VK_NULL_HANDLE)
+	{
+		vkDestroySampler(device, textureSampler, nullptr);
+		textureSampler = VK_NULL_HANDLE;
+	}
+	if (textureImageView != VK_NULL_HANDLE)
+	{
+		vkDestroyImageView(device, textureImageView, nullptr);
+		textureImageView = VK_NULL_HANDLE;
+	}
 	m_imageBuffer->cleanup();
 }
 

--- a/AL/src/Renderer/VulkanContext.cpp
+++ b/AL/src/Renderer/VulkanContext.cpp
@@ -511,7 +511,7 @@ VKAPI_ATTR VkBool32 VKAPI_CALL VulkanContext::debugCallback(VkDebugUtilsMessageS
 															void *pUserData)
 {
 	// 메시지 내용만 출력
-	std::cerr << "validation layer: " << pCallbackData->pMessage << std::endl;
+	std::cout << "validation layer: " << pCallbackData->pMessage << std::endl;
 	// VK_TRUE 반환시 프로그램 종료됨
 	return VK_FALSE;
 }

--- a/AL/src/Renderer/VulkanUtil.cpp
+++ b/AL/src/Renderer/VulkanUtil.cpp
@@ -16,16 +16,16 @@ void VulkanUtil::createImage(uint32_t width, uint32_t height, uint32_t mipLevels
 	imageInfo.imageType = VK_IMAGE_TYPE_2D; // 이미지의 차원을 설정
 	imageInfo.extent.width = width;			// 이미지의 너비 지정
 	imageInfo.extent.height = height;		// 이미지의 높이 지정
-	imageInfo.extent.depth = 1; // 이미지의 깊이 지정 (2D 이미지의 경우 depth는 1로 지정해야 함)
-	imageInfo.mipLevels = mipLevels; // 생성할 mipLevel의 개수 지정
-	imageInfo.arrayLayers = 1;		 // 생성할 이미지 레이어 수 (큐브맵의 경우 6개 생성)
-	imageInfo.format = format; // 이미지의 포맷을 지정하며, 채널 구성과 각 채널의 비트 수를 정의
+	imageInfo.extent.depth = 1;				// 이미지의 깊이 지정 (2D 이미지의 경우 depth는 1로 지정해야 함)
+	imageInfo.mipLevels = mipLevels;		// 생성할 mipLevel의 개수 지정
+	imageInfo.arrayLayers = 1;				// 생성할 이미지 레이어 수 (큐브맵의 경우 6개 생성)
+	imageInfo.format = format;				// 이미지의 포맷을 지정하며, 채널 구성과 각 채널의 비트 수를 정의
 	imageInfo.tiling = tiling; // 이미지를 GPU 메모리에 배치할 때 메모리 레이아웃을 결정하는 설정 (CPU에서도 접근
 							   // 가능하게 할꺼냐, GPU에만 접근 가능하게 최적화 할거냐 결정)
 	imageInfo.initialLayout =
-		VK_IMAGE_LAYOUT_UNDEFINED; // 이미지 초기 레이아웃 설정 (이미지가 메모리에 배치될 때 초기 상태를 정의)
-	imageInfo.usage = usage;						   // 이미지의 사용 용도 결정
-	imageInfo.samples = numSamples;					   // 멀티 샘플링을 위한 샘플 개수
+		VK_IMAGE_LAYOUT_UNDEFINED;	// 이미지 초기 레이아웃 설정 (이미지가 메모리에 배치될 때 초기 상태를 정의)
+	imageInfo.usage = usage;		// 이미지의 사용 용도 결정
+	imageInfo.samples = numSamples; // 멀티 샘플링을 위한 샘플 개수
 	imageInfo.sharingMode = VK_SHARING_MODE_EXCLUSIVE; // 이미지의 큐 공유 모드 설정 (VK_SHARING_MODE_EXCLUSIVE: 한 번에
 													   // 하나의 큐 패밀리에서만 접근 가능한 단일 큐 모드)
 
@@ -244,8 +244,8 @@ VkSampler VulkanUtil::createSampler()
 	// 샘플러 생성시 필요한 구조체
 	VkSamplerCreateInfo samplerInfo{};
 	samplerInfo.sType = VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO;
-	samplerInfo.magFilter = VK_FILTER_LINEAR; // 확대시 필터링 적용 설정 (현재 선형 보간 필터링 적용)
-	samplerInfo.minFilter = VK_FILTER_LINEAR; // 축소시 필터링 적용 설정 (현재 선형 보간 필터링 적용)
+	samplerInfo.magFilter = VK_FILTER_LINEAR;				   // 확대시 필터링 적용 설정 (현재 선형 보간 필터링 적용)
+	samplerInfo.minFilter = VK_FILTER_LINEAR;				   // 축소시 필터링 적용 설정 (현재 선형 보간 필터링 적용)
 	samplerInfo.addressModeU = VK_SAMPLER_ADDRESS_MODE_REPEAT; // 텍스처 좌표계의 U축(너비)에서 범위를 벗어난 경우 래핑
 															   // 모드 설정 (현재 반복 설정)
 	samplerInfo.addressModeV = VK_SAMPLER_ADDRESS_MODE_REPEAT; // 텍스처 좌표계의 V축(높이)에서 범위를 벗어난 경우 래핑
@@ -261,7 +261,7 @@ VkSampler VulkanUtil::createSampler()
 		VK_FALSE; // VK_TRUE로 설정시 텍스처 좌표가 0 ~ 1의 정규화된 좌표가 아닌 실제 텍셀의 좌표 범위로 바뀜
 	samplerInfo.compareEnable =
 		VK_FALSE; // 비교 연산 사용할지 결정 (보통 쉐도우 맵같은 경우 깊이 비교 샘플링에서 사용됨)
-	samplerInfo.compareOp = VK_COMPARE_OP_ALWAYS; // 비교 연산에 사용할 연산 지정
+	samplerInfo.compareOp = VK_COMPARE_OP_ALWAYS;			// 비교 연산에 사용할 연산 지정
 	samplerInfo.mipmapMode = VK_SAMPLER_MIPMAP_MODE_LINEAR; // mipmap 사용시 mipmap 간 보간 방식 결정 (현재 선형 보간)
 	samplerInfo.minLod = 0.0f; // 최소 level을 0으로 설정 (가장 높은 해상도의 mipmap 을 사용가능하게 허용)
 	samplerInfo.maxLod = 1.0f; // 최대 level을 mipLevel로 설정 (VK_LOD_CLAMP_NONE 설정시 제한 해제)
@@ -275,6 +275,64 @@ VkSampler VulkanUtil::createSampler()
 		throw std::runtime_error("failed to create texture sampler!");
 	}
 	return textureSampler;
+}
+
+VkDescriptorSetLayout VulkanUtil::createIconDescriptorSetLayout(VkDevice device, VkDescriptorPool descriptorPool)
+{
+	VkDescriptorSetLayout descriptorSetLayout;
+	VkDescriptorSetLayoutBinding samplerLayoutBinding{};
+	samplerLayoutBinding.binding = 0; // 샘플러를 binding 0으로 설정
+	samplerLayoutBinding.descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
+	samplerLayoutBinding.descriptorCount = 1;
+	samplerLayoutBinding.stageFlags = VK_SHADER_STAGE_FRAGMENT_BIT;
+	samplerLayoutBinding.pImmutableSamplers = nullptr;
+
+	// DescriptorSetLayout 생성
+	VkDescriptorSetLayoutCreateInfo layoutInfo{};
+	layoutInfo.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO;
+	layoutInfo.bindingCount = 1; // 샘플러만 포함
+	layoutInfo.pBindings = &samplerLayoutBinding;
+
+	if (vkCreateDescriptorSetLayout(device, &layoutInfo, nullptr, &descriptorSetLayout) != VK_SUCCESS)
+	{
+		throw std::runtime_error("failed to create sampler-only descriptor set layout!");
+	}
+	return descriptorSetLayout;
+}
+
+VkDescriptorSet VulkanUtil::createIconDescriptorSet(VkDevice device, VkDescriptorPool descriptorPool,
+													VkDescriptorSetLayout descriptorSetLayout, VkImageView imageView,
+													VkSampler sampler)
+{
+	VkDescriptorSet descriptorSet;
+	VkDescriptorSetAllocateInfo allocInfo{};
+	allocInfo.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO;
+	allocInfo.descriptorPool = descriptorPool;
+	allocInfo.descriptorSetCount = 1;
+	allocInfo.pSetLayouts = &descriptorSetLayout;
+
+	if (vkAllocateDescriptorSets(device, &allocInfo, &descriptorSet) != VK_SUCCESS)
+	{
+		throw std::runtime_error("Failed to allocate descriptor set!");
+	}
+
+	VkDescriptorImageInfo imageInfo{};
+	imageInfo.imageView = imageView;
+	imageInfo.sampler = sampler;
+	imageInfo.imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+
+	VkWriteDescriptorSet descriptorWrite{};
+	descriptorWrite.sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
+	descriptorWrite.dstSet = descriptorSet;
+	descriptorWrite.dstBinding = 0;
+	descriptorWrite.dstArrayElement = 0;
+	descriptorWrite.descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
+	descriptorWrite.descriptorCount = 1;
+	descriptorWrite.pImageInfo = &imageInfo;
+
+	vkUpdateDescriptorSets(device, 1, &descriptorWrite, 0, nullptr);
+
+	return descriptorSet;
 }
 
 ImTextureID VulkanUtil::createIconTexture(VkDevice device, VkDescriptorPool descriptorPool, VkImageView imageView,

--- a/Sandbox/src/EditorLayer.cpp
+++ b/Sandbox/src/EditorLayer.cpp
@@ -23,12 +23,20 @@ void EditorLayer::onAttach()
 	descriptorPool = context.getDescriptorPool();
 	device = context.getDevice();
 
-	playTextureID =
-		VulkanUtil::createIconTexture(device, descriptorPool, m_PlayIcon->getImageView(), m_PlayIcon->getSampler());
-	pauseTextureID =
-		VulkanUtil::createIconTexture(device, descriptorPool, m_PauseIcon->getImageView(), m_PauseIcon->getSampler());
-	stepTextureID =
-		VulkanUtil::createIconTexture(device, descriptorPool, m_StepIcon->getImageView(), m_StepIcon->getSampler());
+	iconDescriptorSetLayout = VulkanUtil::createIconDescriptorSetLayout(device, descriptorPool);
+	playDescriptorSet = VulkanUtil::createIconDescriptorSet(device, descriptorPool, iconDescriptorSetLayout,
+															m_PlayIcon->getImageView(), m_PlayIcon->getSampler());
+	pauseDescriptorSet = VulkanUtil::createIconDescriptorSet(device, descriptorPool, iconDescriptorSetLayout,
+															 m_PauseIcon->getImageView(), m_PauseIcon->getSampler());
+	stepDescriptorSet = VulkanUtil::createIconDescriptorSet(device, descriptorPool, iconDescriptorSetLayout,
+															m_StepIcon->getImageView(), m_StepIcon->getSampler());
+
+	// playTextureID =
+	// 	VulkanUtil::createIconTexture(device, descriptorPool, m_PlayIcon->getImageView(), m_PlayIcon->getSampler());
+	// pauseTextureID =
+	// 	VulkanUtil::createIconTexture(device, descriptorPool, m_PauseIcon->getImageView(), m_PauseIcon->getSampler());
+	// stepTextureID =
+	// 	VulkanUtil::createIconTexture(device, descriptorPool, m_StepIcon->getImageView(), m_StepIcon->getSampler());
 
 	auto cmdLineArgs = App::get().getSpecification().m_CommandLineArgs;
 
@@ -50,6 +58,13 @@ void EditorLayer::onAttach()
 void EditorLayer::onDetach()
 {
 	// texture clean up
+	m_PlayIcon->cleanup();
+	m_PauseIcon->cleanup();
+	m_StepIcon->cleanup();
+
+	vkDestroyDescriptorSetLayout(device, iconDescriptorSetLayout, nullptr);
+
+	m_EditorScene->cleanup();
 }
 
 void EditorLayer::onUpdate(Timestep ts)
@@ -295,8 +310,8 @@ void EditorLayer::uiToolBar()
 	static bool isPlayPressed = false;
 	static bool isPausePressed = false;
 
-	if (ImGui::ImageButton("a", playTextureID, ImVec2(size + 4, size), ImVec2(0, 0), ImVec2(1, 1),
-						   ImVec4(0.0f, 0.0f, 0.0f, 0.45f), isPlayPressed ? activeColor : tintColor) &&
+	if (ImGui::ImageButton("a", reinterpret_cast<ImTextureID>(playDescriptorSet), ImVec2(size + 4, size), ImVec2(0, 0),
+						   ImVec2(1, 1), ImVec4(0.0f, 0.0f, 0.0f, 0.45f), isPlayPressed ? activeColor : tintColor) &&
 		toolbarEnabled)
 	{
 		isPlayPressed = !isPlayPressed;
@@ -310,8 +325,9 @@ void EditorLayer::uiToolBar()
 		ImGui::BeginDisabled();
 	ImGui::SameLine();
 	{
-		if (ImGui::ImageButton("b", pauseTextureID, ImVec2(size + 4, size), ImVec2(0, 0), ImVec2(1, 1),
-							   ImVec4(0.0f, 0.0f, 0.0f, 0.45f), isPausePressed ? activeColor : tintColor) &&
+		if (ImGui::ImageButton("b", reinterpret_cast<ImTextureID>(pauseDescriptorSet), ImVec2(size + 4, size),
+							   ImVec2(0, 0), ImVec2(1, 1), ImVec4(0.0f, 0.0f, 0.0f, 0.45f),
+							   isPausePressed ? activeColor : tintColor) &&
 			toolbarEnabled)
 		{
 			isPausePressed = !isPausePressed;
@@ -325,8 +341,8 @@ void EditorLayer::uiToolBar()
 		ImGui::BeginDisabled();
 	ImGui::SameLine();
 	{
-		if (ImGui::ImageButton("c", stepTextureID, ImVec2(size + 4, size), ImVec2(0, 0), ImVec2(1, 1),
-							   ImVec4(0.0f, 0.0f, 0.0f, 0.45f), tintColor) &&
+		if (ImGui::ImageButton("c", reinterpret_cast<ImTextureID>(stepDescriptorSet), ImVec2(size + 4, size),
+							   ImVec2(0, 0), ImVec2(1, 1), ImVec4(0.0f, 0.0f, 0.0f, 0.45f), tintColor) &&
 			toolbarEnabled)
 		{
 			isPausePressed = true;

--- a/Sandbox/src/EditorLayer.h
+++ b/Sandbox/src/EditorLayer.h
@@ -22,6 +22,16 @@ class EditorLayer : public Layer
 	void onImGuiRender() override;
 	void onEvent(Event &e) override;
 
+	// getters scene
+	std::shared_ptr<Scene> getEditorScene() const
+	{
+		return m_EditorScene;
+	}
+	std::shared_ptr<Scene> getActiveScene() const
+	{
+		return m_ActiveScene;
+	}
+
   private:
 	// EVENTS
 	bool onMouseButtonPressed(MouseButtonPressedEvent &e);
@@ -83,6 +93,8 @@ class EditorLayer : public Layer
 	ESceneState m_SceneState = ESceneState::EDIT;
 	std::shared_ptr<Texture> m_PlayIcon, m_PauseIcon, m_StepIcon;
 	ImTextureID playTextureID, pauseTextureID, stepTextureID;
+	VkDescriptorSetLayout iconDescriptorSetLayout;
+	VkDescriptorSet playDescriptorSet, pauseDescriptorSet, stepDescriptorSet;
 };
 
 } // namespace ale

--- a/Sandbox/src/Panel/ContentBrowserPanel.h
+++ b/Sandbox/src/Panel/ContentBrowserPanel.h
@@ -26,6 +26,9 @@ class ContentBrowserPanel
 	VkDescriptorPool descriptorPool;
 	VkDevice device;
 
+	VkDescriptorSetLayout iconDescriptorSetLayout;
+	VkDescriptorSet directoryDescriptorSet;
+	VkDescriptorSet fileDescriptorSet;
 	std::shared_ptr<Texture> m_DirectoryIcon;
 	std::shared_ptr<Texture> m_FileIcon;
 	ImTextureID directoryTextureID;


### PR DESCRIPTION


### **주요 변경 사항**  

#### 1. **리소스 정리 및 메모리 관리 개선**  
##### (1) **버퍼 및 텍스처 정리 로직 추가** (`Buffer.cpp`, `Texture.cpp`)  
- `cleanup()` 함수에서 Vulkan 객체 삭제 후 `VK_NULL_HANDLE`로 초기화하여 메모리 해제 후 재사용 방지.  
- `ImageBuffer`, `VertexBuffer`, `IndexBuffer`, `UniformBuffer` 등 여러 렌더링 리소스에 적용.  

##### (2) **렌더링 리소스 정리 기능 추가** (`Renderer.cpp`, `Material.cpp`, `Model.cpp`)  
- `Renderer::cleanup()` 함수 추가 → 모델, 프레임버퍼, 파이프라인, 쉐이더 리소스 정리 로직 포함.  
- `Material::cleanup()`, `Model::cleanup()` 추가 → 관련된 텍스처 및 리소스 정리.  

##### (3) **씬 정리 로직 추가** (`Scene.cpp`)  
- `Scene::cleanup()` 함수 추가하여 기본 모델 및 렌더링 리소스 해제.  
- `MeshRendererComponent`가 사용하는 `RenderingComponent` 정리.  

##### (4) **애플리케이션 종료 시 리소스 해제** (`App.cpp`)  
- `App::~App()`에서 `m_Renderer->cleanup();` 및 `m_LayerStack.onDetach();` 호출.  
- `LayerStack::onDetach()` 추가하여 등록된 레이어 정리.  

---

#### 2. **렌더링 개선**  
##### (1) **불필요한 Shader Resource Manager 제거** (`Renderer.h`, `Renderer.cpp`)  
- `geometryPassShaderResourceManager`, `lightingPassShaderResourceManager` 제거하여 사용되지 않는 리소스 삭제.  

##### (2) **아이콘 시스템 개선** (`VulkanUtil.h`, `VulkanUtil.cpp`)  
- `createIconDescriptorSetLayout()`, `createIconDescriptorSet()` 함수 추가.  
- 새로운 아이콘 렌더링 방식을 사용하여 **UI 요소의 이미지 렌더링 최적화**.  

---

#### 3. **UI 아이콘 시스템 개선**  
##### (1) **에디터 UI 아이콘 개선** (`EditorLayer.cpp`, `EditorLayer.h`)  
- `playTextureID`, `pauseTextureID`, `stepTextureID` 대신 **DescriptorSet을 활용한 아이콘 렌더링 방식으로 변경**.  
- `iconDescriptorSetLayout` 및 `playDescriptorSet`, `pauseDescriptorSet`, `stepDescriptorSet` 추가.  
- `onAttach()`에서 아이콘 DescriptorSet을 생성하고 `onDetach()`에서 정리.  
- `ImGui::ImageButton()`을 `reinterpret_cast<ImTextureID>(playDescriptorSet)` 방식으로 변경하여 최적화.  

##### (2) **콘텐츠 브라우저 UI 아이콘 개선** (`ContentBrowserPanel.cpp`, `ContentBrowserPanel.h`)  
- `directoryTextureID`, `fileTextureID`를 DescriptorSet 기반으로 변경.  
- 기존 `ImTextureID` 사용 대신 `reinterpret_cast<ImTextureID>(directoryDescriptorSet)` 적용.  
- `createIconDescriptorSetLayout()` 및 `createIconDescriptorSet()` 활용.  
- `ContentBrowserPanel::~ContentBrowserPanel()`에서 `vkDestroyDescriptorSetLayout()` 호출하여 정리.  
