### PR TITLE
[Bug]: remove object error

### DIFF
--- a/AL/include/Scene/Component.h
+++ b/AL/include/Scene/Component.h
@@ -92,9 +92,9 @@ struct MeshRendererComponent
 	bool isMatChanged = false;
 
 	// Culling
-	int32_t nodeId;
+	int32_t nodeId = NULL_NODE;
 	CullSphere cullSphere;
-	bool renderEnabled;
+	ECullState cullState;
 
 	MeshRendererComponent() = default;
 	MeshRendererComponent(const MeshRendererComponent &) = default;

--- a/AL/include/Scene/CullTree.h
+++ b/AL/include/Scene/CullTree.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include "Renderer/Common.h"
 #include "Core/Log.h"
+#include "Renderer/Common.h"
 
 namespace ale
 {
@@ -26,11 +26,9 @@ struct CullSphere
 
 	CullSphere() = default;
 
-	CullSphere(glm::vec3 &center, float radius)
-		: center(center), radius(radius) {};
+	CullSphere(glm::vec3 &center, float radius) : center(center), radius(radius) {};
 
-	CullSphere(glm::vec4 &center, float radius)
-		: center(center), radius(radius) {};
+	CullSphere(glm::vec4 &center, float radius) : center(center), radius(radius) {};
 
 	float getVolume()
 	{

--- a/AL/include/Scene/CullTree.h
+++ b/AL/include/Scene/CullTree.h
@@ -8,6 +8,17 @@ namespace ale
 
 #define NULL_NODE (-1)
 
+enum class ECullState
+{
+	CULL = 0,
+	RENDER = (1 << 0),
+	NONE = (1 << 1),
+	RENDER_AND_NONE = (1 << 0) | (1 << 1),
+};
+
+ECullState operator&(ECullState state1, ECullState state2);
+ECullState operator|(ECullState state1, ECullState state2);
+
 struct CullSphere
 {
 	glm::vec3 center;

--- a/AL/include/Scene/Entity.h
+++ b/AL/include/Scene/Entity.h
@@ -44,8 +44,7 @@ class Entity
 	// 템플릿 완전 특수화
 	template <> void removeComponent<MeshRendererComponent>()
 	{
-		auto &component = m_Scene->getComponent<MeshRendererComponent>(m_EntityHandle);
-		m_Scene->removeEntityInCullTree(component.nodeId);
+		m_Scene->removeEntityInCullTree(*this);
 		m_Scene->m_Registry.remove<MeshRendererComponent>(m_EntityHandle);
 	}
 

--- a/AL/include/Scene/Scene.h
+++ b/AL/include/Scene/Scene.h
@@ -119,8 +119,10 @@ class Scene
 	// frustumCulling
 	void frustumCulling(const Frustum &frustum);
 	void initFrustumDrawFlag();
-	void removeEntityInCullTree(int32_t nodeId);
-	int32_t insertEntityInCullTree(const CullSphere &sphere, entt::entity entityHandle);
+	void removeEntityInCullTree(Entity &entity);
+	void insertEntityInCullTree(Entity &entity);
+	void setNoneInCullTree(Entity &entity);
+	void unsetNoneInCullTree(Entity &entity);
 	void printCullTree();
 
   private:

--- a/AL/src/Renderer/Renderer.cpp
+++ b/AL/src/Renderer/Renderer.cpp
@@ -906,7 +906,7 @@ void Renderer::recordDeferredRenderPassCommandBuffer(Scene *scene, VkCommandBuff
 		}
 		drawInfo.model = view.get<TransformComponent>(entity).m_WorldTransform;
 		MeshRendererComponent &meshRendererComponent = view.get<MeshRendererComponent>(entity);
-		if (meshRendererComponent.renderEnabled == true)
+		if (meshRendererComponent.cullState == ECullState::RENDER)
 		{
 			// drawNum++;
 			meshRendererComponent.m_RenderingComponent->draw(drawInfo);
@@ -1117,7 +1117,7 @@ void Renderer::recordShadowMapCommandBuffer(Scene *scene, VkCommandBuffer comman
 		drawInfo.model = view.get<TransformComponent>(entity).m_WorldTransform;
 
 		MeshRendererComponent &meshRendererComponent = view.get<MeshRendererComponent>(entity);
-		if (meshRendererComponent.renderEnabled == true)
+		if (meshRendererComponent.cullState == ECullState::RENDER)
 		{
 			meshRendererComponent.m_RenderingComponent->drawShadow(drawInfo, shadowMapIndex);
 		}
@@ -1209,7 +1209,7 @@ void Renderer::recordShadowCubeMapCommandBuffer(Scene *scene, VkCommandBuffer co
 		}
 		drawInfo.model = view.get<TransformComponent>(entity).m_WorldTransform;
 		MeshRendererComponent &meshRendererComponent = view.get<MeshRendererComponent>(entity);
-		if (meshRendererComponent.renderEnabled == true)
+		if (meshRendererComponent.cullState == ECullState::RENDER)
 		{
 			meshRendererComponent.m_RenderingComponent->drawShadowCubeMap(drawInfo, shadowMapIndex);
 		}

--- a/AL/src/Scene/CullTree.cpp
+++ b/AL/src/Scene/CullTree.cpp
@@ -123,7 +123,7 @@ void CullTree::setRenderEnable(int32_t nodeId)
 	{
 		MeshRendererComponent &component =
 			m_scene->getComponent<MeshRendererComponent>(static_cast<entt::entity>(node.entityHandle));
-		component.renderEnabled = true;
+		component.cullState = (component.cullState | ECullState::RENDER);
 	}
 	else
 	{
@@ -140,7 +140,7 @@ void CullTree::setRenderDisable(int32_t nodeId)
 	{
 		MeshRendererComponent &component =
 			m_scene->getComponent<MeshRendererComponent>(static_cast<entt::entity>(node.entityHandle));
-		component.renderEnabled = false;
+		component.cullState = (component.cullState & ECullState::NONE);
 	}
 	else
 	{
@@ -383,13 +383,13 @@ void CullTree::printCullTree(int32_t nodeId)
 	}
 
 	AL_CORE_INFO("nodeId: {} start", nodeId);
-	AL_CORE_INFO("Sphere center: {}, {}, {}", m_nodes[nodeId].sphere.center.x, m_nodes[nodeId].sphere.center.y,
-				 m_nodes[nodeId].sphere.center.z);
-	AL_CORE_INFO("Sphere radius: {}", m_nodes[nodeId].sphere.radius);
+	// AL_CORE_INFO("Sphere center: {}, {}, {}", m_nodes[nodeId].sphere.center.x, m_nodes[nodeId].sphere.center.y,
+	// 			 m_nodes[nodeId].sphere.center.z);
+	// AL_CORE_INFO("Sphere radius: {}", m_nodes[nodeId].sphere.radius);
 	AL_CORE_INFO("entityHandle: {}", m_nodes[nodeId].entityHandle);
 	AL_CORE_INFO("child1: {}", m_nodes[nodeId].child1);
 	AL_CORE_INFO("child2: {}", m_nodes[nodeId].child2);
-	AL_CORE_INFO("height: {}", m_nodes[nodeId].height);
+	// AL_CORE_INFO("height: {}", m_nodes[nodeId].height);
 	printCullTree(m_nodes[nodeId].child1);
 	printCullTree(m_nodes[nodeId].child2);
 }
@@ -528,6 +528,20 @@ int32_t CullTree::balance(int32_t iA)
 void CullTree::changeEntityHandle(int32_t nodeId, uint32_t entityHandle)
 {
 	m_nodes[nodeId].entityHandle = entityHandle;
+}
+
+ECullState operator&(ECullState state1, ECullState state2)
+{
+	int32_t s1 = static_cast<int32_t>(state1);
+	int32_t s2 = static_cast<int32_t>(state2);
+	return static_cast<ECullState>(s1 & s2);
+}
+
+ECullState operator|(ECullState state1, ECullState state2)
+{
+	int32_t s1 = static_cast<int32_t>(state1);
+	int32_t s2 = static_cast<int32_t>(state2);
+	return static_cast<ECullState>(s1 | s2);
 }
 
 } // namespace ale

--- a/AL/src/Scene/SceneSerializer.cpp
+++ b/AL/src/Scene/SceneSerializer.cpp
@@ -529,11 +529,8 @@ bool SceneSerializer::deserialize(const std::string &filepath)
 				mc.m_RenderingComponent = RenderingComponent::createRenderingComponent(model);
 
 				mc.cullSphere = mc.m_RenderingComponent->getCullSphere();
-				TransformComponent &transformComponent = m_Scene->getComponent<TransformComponent>(deserializedEntity);
-				CullSphere sphere(transformComponent.getTransform() * glm::vec4(mc.cullSphere.center, 1.0f),
-								  mc.cullSphere.radius * transformComponent.getMaxScale());
 				// cullTree에 추가 sphere
-				mc.nodeId = m_Scene->insertEntityInCullTree(sphere, deserializedEntity);
+				m_Scene->insertEntityInCullTree(deserializedEntity);
 
 				if (mc.isMatChanged)
 				{

--- a/Sandbox/src/Panel/SceneHierarchyPanel.cpp
+++ b/Sandbox/src/Panel/SceneHierarchyPanel.cpp
@@ -724,6 +724,13 @@ void SceneHierarchyPanel::drawComponents(Entity entity)
 					component.type = i;
 					if (i == 0) // None
 					{
+						component.path.clear();
+						component.matPath.clear();
+						component.isMatChanged = false;
+						// scene->insertEntityInCullTree(entity);
+						scene->removeEntityInCullTree(entity);
+						component.m_RenderingComponent = nullptr;
+						component.cullState = ECullState::NONE;
 					}
 					else if (i == 7)
 					{
@@ -736,6 +743,7 @@ void SceneHierarchyPanel::drawComponents(Entity entity)
 						component.path.clear();
 						component.matPath.clear();
 						component.isMatChanged = false;
+						scene->insertEntityInCullTree(entity);
 					}
 				}
 				if (isSelected)
@@ -764,6 +772,7 @@ void SceneHierarchyPanel::drawComponents(Entity entity)
 					component.type = 7;
 					component.path = filePath.string();
 					component.isMatChanged = false;
+					scene->insertEntityInCullTree(entity);
 				}
 			}
 			ImGui::EndDragDropTarget();
@@ -786,35 +795,39 @@ void SceneHierarchyPanel::drawComponents(Entity entity)
 			}
 			ImGui::EndDragDropTarget();
 		}
-		auto &materials = rc->getMaterials();
 
-		static int32_t idx = 0;
-		ImGui::DragInt("Material Index", &idx, 0.1f, 0, materials.size() - 1, "%d");
-		idx = std::clamp(idx, 0, static_cast<int32_t>(materials.size()) - 1);
+		if (rc != nullptr)
+		{
+			auto &materials = rc->getMaterials();
 
-		std::shared_ptr<Material> &material = materials[idx];
-		Albedo &albedo = material->getAlbedo();
-		drawVec3Control("Albedo", albedo.albedo);
-		drawCheckBox("Albedo Flag", albedo.flag);
+			static int32_t idx = 0;
+			ImGui::DragInt("Material Index", &idx, 0.1f, 0, materials.size() - 1, "%d");
+			idx = std::clamp(idx, 0, static_cast<int32_t>(materials.size()) - 1);
 
-		NormalMap &normalMap = material->getNormalMap();
-		drawCheckBox("Normal Flag", normalMap.flag);
+			std::shared_ptr<Material> &material = materials[idx];
+			Albedo &albedo = material->getAlbedo();
+			drawVec3Control("Albedo", albedo.albedo);
+			drawCheckBox("Albedo Flag", albedo.flag);
 
-		Roughness &roughness = material->getRoughness();
-		drawFloatControl("Roughness", roughness.roughness);
-		drawCheckBox("Roughness Flag", roughness.flag);
+			NormalMap &normalMap = material->getNormalMap();
+			drawCheckBox("Normal Flag", normalMap.flag);
 
-		Metallic &metalic = material->getMetallic();
-		drawFloatControl("Metallic", metalic.metallic);
-		drawCheckBox("Metallic Flag", metalic.flag);
+			Roughness &roughness = material->getRoughness();
+			drawFloatControl("Roughness", roughness.roughness);
+			drawCheckBox("Roughness Flag", roughness.flag);
 
-		AOMap &aoMap = material->getAOMap();
-		drawFloatControl("AOMap", aoMap.ao);
-		drawCheckBox("AOMap Flag", aoMap.flag);
+			Metallic &metalic = material->getMetallic();
+			drawFloatControl("Metallic", metalic.metallic);
+			drawCheckBox("Metallic Flag", metalic.flag);
 
-		HeightMap &heightMap = material->getHeightMap();
-		drawFloatControl("HeightMap", heightMap.height);
-		drawCheckBox("HeightMap Flag", heightMap.flag);
+			AOMap &aoMap = material->getAOMap();
+			drawFloatControl("AOMap", aoMap.ao);
+			drawCheckBox("AOMap Flag", aoMap.flag);
+
+			HeightMap &heightMap = material->getHeightMap();
+			drawFloatControl("HeightMap", heightMap.height);
+			drawCheckBox("HeightMap Flag", heightMap.flag);
+		}
 	});
 
 	drawComponent<LightComponent>("Light", entity, [entity, scene = m_Context](auto &component) mutable {


### PR DESCRIPTION
본 PR은 컬링 시스템을 리팩토링하여 `ECullState`를 도입하고, 컬링 트리에서의 엔티티 추가/제거 방식을 수정하며, 관련 렌더링 로직을 업데이트합니다. 이를 통해 컬링 상태를 보다 효율적으로 관리할 수 있으며, 불필요한 연산을 제거하여 성능을 개선합니다.  

#### **변경 사항 개요**  

- **`MeshRendererComponent` 컬링 상태 리팩토링**  
  - 기존의 `renderEnabled` 불리언 변수를 `ECullState` 열거형(Enum)으로 변경  
  - 컬링 상태를 비트 연산을 통해 설정 및 해제할 수 있도록 개선  

- **컬링 트리 연산 방식 변경 (`Scene.h` 및 `Scene.cpp`)**  
  - 기존 `removeEntityInCullTree(int32_t nodeId)` → `removeEntityInCullTree(Entity &entity)`로 변경  
  - 기존 `insertEntityInCullTree(const CullSphere &sphere, entt::entity entityHandle)` → `insertEntityInCullTree(Entity &entity)`로 변경  
  - 엔티티가 `MeshRendererComponent`를 가지고 있는 경우에만 컬링 트리에 삽입되도록 변경  
  - 컬링 트리에서 `NONE` 상태 설정/해제 기능 (`setNoneInCullTree()`, `unsetNoneInCullTree()`) 추가  

- **렌더링 관련 변경 (`Renderer.cpp`)**  
  - `renderEnabled` 대신 `cullState == ECullState::RENDER` 여부로 렌더링할지 결정  

- **컬링 트리 연산 최적화 (`CullTree.cpp`)**  
  - `setRenderEnable()` 및 `setRenderDisable()`에서 `cullState` 비트 연산을 활용하도록 수정  
  - 불필요한 `AL_CORE_INFO` 로그 출력 제거  

- **엔티티 컴포넌트 관리 로직 수정 (`Entity.h`, `SceneSerializer.cpp`, `SceneHierarchyPanel.cpp`)**  
  - `removeComponent<MeshRendererComponent>()`에서 컬링 트리 제거 로직 수정  
  - 엔티티 생성 및 로드 시 컬링 트리 삽입 방식 변경  
  - UI에서 `MeshRendererComponent`가 변경될 때 컬링 트리에서 적절히 추가/제거되도록 수정  

#### **변경 이유**  
- 컬링 상태를 보다 직관적이고 확장 가능하게 만들기 위해 `ECullState`를 도입  
- 불필요한 컬링 트리 연산을 줄여 성능을 개선  
- 컬링 상태 관리 방식을 일관되게 유지하고 코드 가독성을 향상  

#### **테스트 사항**  
- 씬 내 엔티티의 컬링 및 렌더링 상태가 정상적으로 변경되는지 확인  
- `setNoneInCullTree()` 및 `unsetNoneInCullTree()` 호출 시 올바르게 동작하는지 검증  
- `SceneHierarchyPanel`에서 메쉬 변경 시 컬링 트리 연동이 정상적으로 이루어지는지 확인  
- 기존 씬 직렬화/역직렬화 과정이 정상적으로 동작하는지 테스트  
